### PR TITLE
feat(jenkins): add kaniko image to shared pod

### DIFF
--- a/charts/molgenis-jenkins/Chart.yaml
+++ b/charts/molgenis-jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: molgenis-jenkins
 home: https://jenkins.io/
-version: 0.17.0
+version: 0.18.0
 appVersion: 2.150.3
 description: Molgenis installation for the jenkins chart.
 sources:

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -587,6 +587,13 @@ jenkins:
           hostPath: "/var/run/docker.sock"
           mountPath: "/var/run/docker.sock"
       Containers:
+        kaniko:
+          Image: "gcr.io/kaniko-project/executor"
+          ImageTag: "debug-v0.7.0"
+          AlwaysPullImage: false
+          Command: cat
+          WorkingDir: /home/jenkins
+          TTY: true
         rancher:
           Image: "rancher/cli2"
           ImageTag: "v2.0.6"


### PR DESCRIPTION
Use the 0.7.0 image because of https://github.com/GoogleContainerTools/kaniko/issues/641
Use debug image because we need to run sh and the default image is extremely slim.