### PR TITLE
[FEAT] [molgenis-frontend]: determine host based on environment and add notes.txt

### DIFF
--- a/charts/molgenis-frontend/Chart.yaml
+++ b/charts/molgenis-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "8.0"
 description: MOLGENIS Helm chart for the frontend
 name: molgenis-frontend
-version: 0.0.1
+version: 0.0.2
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 icon: https://github.com/molgenis/molgenis-ops-helm/raw/master/charts/molgenis-frontend/catalogIcon-molgenis-frontend.png

--- a/charts/molgenis-frontend/Chart.yaml
+++ b/charts/molgenis-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "8.0"
 description: MOLGENIS Helm chart for the frontend
 name: molgenis-frontend
-version: 0.0.2
+version: 0.1.0
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 icon: https://github.com/molgenis/molgenis-ops-helm/raw/master/charts/molgenis-frontend/catalogIcon-molgenis-frontend.png

--- a/charts/molgenis-frontend/questions.yml
+++ b/charts/molgenis-frontend/questions.yml
@@ -2,13 +2,18 @@
 categories:
 - MOLGENIS
 questions:
-- variable: ingress.hosts[0].name
-  label: Hostname(s)
-  default: "frontend.molgenis.org"
-  description: "Specify a hostname"
-  type: string
+- variable: environment
+  label: Environment
+  description: "Environment of MOLGENIS instance"
+  type: enum
+  options:
+    - edge
+    - dev
+    - test
+    - accept
+    - prod
   required: true
-  group: "Loadbalancing"
+  group: "Provisioning"
 - variable: image.image.tag
   label: Version
   default: "dev"

--- a/charts/molgenis-frontend/templates/NOTES.txt
+++ b/charts/molgenis-frontend/templates/NOTES.txt
@@ -1,1 +1,1 @@
-Deployed frontend {{ .Values.image.tag }} proxying {{ .Values.backend.url }} on https://{{ .ingress.hosts[0].name }} .
+Deployed frontend {{ .Values.image.tag }} proxying {{ .Values.backend.url }} on https://{{ template "hostname" . }} .

--- a/charts/molgenis-frontend/templates/NOTES.txt
+++ b/charts/molgenis-frontend/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Deployed frontend {{ .Values.image.tag }} proxying {{ .Values.backend.url }} on https://{{ .ingress.hosts[0].name }} .

--- a/charts/molgenis-frontend/templates/_helpers.tpl
+++ b/charts/molgenis-frontend/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "frontend.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Resolve hostname for environment
+*/}}
+{{- define "hostname" -}}
+{{- if ne (.Values.environment | default "prod" ) "prod" -}}
+{{- printf "%s.%s.molgenis.org" .Release.Name .Values.environment -}}
+{{- else -}}
+{{- printf "%s.molgenis.org" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/molgenis-frontend/templates/ingress.yaml
+++ b/charts/molgenis-frontend/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled }}
+{{- $fullName := include "frontend.fullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -25,22 +26,16 @@ metadata:
     {{- end }}
 spec:
   rules:
-  {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ $.Release.Name }}-{{ $.Values.service.name }}
-            servicePort: {{ $.Values.service.port }}
-  {{- end }}
-{{- if .tls }}
-  tls:
-  - hosts:
-    {{- range .Values.ingress.hosts }}
-    - {{ .name }}
-    {{- end }}
-    secretName: {{ .Values.ingress.tlsSecret }}
-{{- end }}
+    - host: {{ template "hostname" . }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $.Values.service.port }}
+      alpn:
+        - h2
+        - http/1.1
+        - http/1.0
 ---
 {{- end }}

--- a/charts/molgenis-frontend/values.yaml
+++ b/charts/molgenis-frontend/values.yaml
@@ -4,8 +4,6 @@
 
 replicaCount: 1
 
-environment: production
-
 strategy:
   type: Recreate
 restartPolicy: Always
@@ -24,14 +22,10 @@ service:
 backend:
   url: https://latest.test.molgenis.org
 
+environment: dev
+
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-  path: /
-  hosts:
-  - name: frontend.molgenis.org
-  tls: []
 
 nodeSelector: {}
 


### PR DESCRIPTION
Otherwise the rancher client doesn't know when the chart is deployed.