### PR TITLE
feat(frontend): make image and path configurable

### DIFF
--- a/charts/molgenis-frontend/Chart.yaml
+++ b/charts/molgenis-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "8.1"
 description: MOLGENIS Helm chart for the frontend
 name: molgenis-frontend
-version: 1.0.3
+version: 1.1.0
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 icon: https://github.com/molgenis/molgenis-ops-helm/raw/master/charts/molgenis-frontend/catalogIcon-molgenis-frontend.png

--- a/charts/molgenis-frontend/questions.yml
+++ b/charts/molgenis-frontend/questions.yml
@@ -35,6 +35,13 @@ questions:
   type: boolean
   required: true
   group: "Advanced"
+- variable: image.name
+  show_if: "questions.advanced=true"
+  label: Image name
+  default: molgenis/molgenis-frontend
+  type: string
+  group: Provisioning
+  required: true
 - variable: image.repository
   show_if: "questions.advanced=true"
   label: Registry
@@ -46,3 +53,9 @@ questions:
     - "registry.molgenis.org"
   required: true
   group: "Provisioning"
+- variable: service.path
+  show_if: "questions.advanced=true"
+  label: "Proxy path"
+  type: string
+  default: '/@molgenis-ui'
+  required: true

--- a/charts/molgenis-frontend/templates/ingress.yaml
+++ b/charts/molgenis-frontend/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
     - host: {{ template "hostname" . }}
       http:
         paths:
-          - path: /@molgenis-ui
+          - path: {{ .values.service.path }}
             backend:
               serviceName: {{ .Release.Name }}-{{ .Values.service.name }}
               servicePort: {{ .Values.service.port }}

--- a/charts/molgenis-frontend/values.yaml
+++ b/charts/molgenis-frontend/values.yaml
@@ -18,6 +18,7 @@ service:
   name: molgenis-frontend
   type: ClusterIP
   port: 80
+  path: '/@molgenis-ui'
 
 molgenis-proxy:
   url: http://master-molgenis.molgenis-abcde.svc:8080/


### PR DESCRIPTION
I'd like to use this for app image previews which have different
docker image name and ingress service path