### PR TITLE
[JENKINS][FIX]: Use full app id

### DIFF
--- a/charts/molgenis-jenkins/resources/tests/e2e-commander/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/e2e-commander/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
                 container('rancher') {
                     sh "rancher context switch dev-molgenis"
                     sh "rancher apps install " +
-                            "molgenis " +
+                            "cattle-global-data:molgenis-helm-molgenis " +
                             "${TAG} " +
                             "--no-prompt " +
                             "--set adminPassword=admin " +

--- a/charts/molgenis-jenkins/resources/tests/e2e/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/e2e/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                     sh "rancher context switch dev-molgenis"
                     sh "rancher apps install " +
                             "-n molgenis-${TAG} " +
-                            "molgenis " +
+                            "cattle-global-data:molgenis-helm-molgenis " +
                             "${TAG} " +
                             "--no-prompt " +
                             "--set adminPassword=${REST_TEST_ADMIN_PW} " +

--- a/charts/molgenis-jenkins/resources/tests/live/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/live/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
                     sh "rancher context switch dev-molgenis"
                     sh "rancher apps install " +
                             "-n molgenis-${TAG} " +
-                            "molgenis " +
+                            "cattle-global-data:molgenis-helm-molgenis " +
                             "${TAG} " +
                             "--version ${CHART_VERSION} " +
                             "--no-prompt " +


### PR DESCRIPTION
There are multiple apps named 'molgenis', use the full app id to avoid conflicts