### PR TITLE
fix(vault): warn about special characters

### DIFF
--- a/charts/molgenis-vault/Chart.yaml
+++ b/charts/molgenis-vault/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: MOLGENIS vault
 name: molgenis-vault
-version: 0.1.5
+version: 0.1.6
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 icon: https://raw.githubusercontent.com/molgenis/molgenis-ops-helm/master/charts/molgenis-vault/catalogIcon-molgenis-vault.png

--- a/charts/molgenis-vault/questions.yml
+++ b/charts/molgenis-vault/questions.yml
@@ -13,11 +13,13 @@ questions:
     required: true
   - variable: aws.secretAccessKey
     label: Backup S3 secret
+    description: Backups fail if this contains special characters!
     group: backup
     type: string
     required: true
   - variable: aws.endpoint
     label: Backup S3 endpoint
+    description: Backups fail if this contains special characters!
     group: backup
     type: string
     required: true


### PR DESCRIPTION
If the s3 credentials contain special characters, the backup and restore will fail.
Add a description to warn the user about this.

This is a workaround for #199

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
