### PR TITLE
fix(jenkins): do not switch to molgenis-dev

### DIFF
--- a/charts/molgenis-jenkins/Chart.yaml
+++ b/charts/molgenis-jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: molgenis-jenkins
 home: https://jenkins.io/
-version: 0.22.1
+version: 0.22.2
 appVersion: 2.150.3
 description: Molgenis installation for the jenkins chart.
 sources:

--- a/charts/molgenis-jenkins/resources/preview/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/preview/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
                     sh(script: 'vault read -field=value secret/ops/jenkins/rancher/cli2.json > /home/jenkins/.rancher/cli2.json')
                 }
                 container('rancher') {
-                    sh "rancher context switch dev-molgenis"
                     sh "rancher apps install " +
                             "-n preview-${TAG.toLowerCase()} " +
                             "cattle-global-data:molgenis-helm-molgenis " +
@@ -51,7 +50,6 @@ pipeline {
                     sh(script: 'vault read -field=value secret/ops/jenkins/rancher/cli2.json > /home/jenkins/.rancher/cli2.json')
                 }
                 container('rancher') {
-                    sh "rancher context switch dev-molgenis"
                     sh "rancher apps delete preview-${TAG.toLowerCase()}"
                 }
                 hubotSend message: "Deleted preview-${TAG.toLowerCase()}"
@@ -67,7 +65,6 @@ pipeline {
                     sh(script: 'vault read -field=value secret/ops/jenkins/rancher/cli2.json > /home/jenkins/.rancher/cli2.json')
                 }
                 container('rancher') {
-                    sh "rancher context switch dev-molgenis"
                     script {
                         env.LIST = sh script: "rancher apps ls", returnStdout: true
                     }

--- a/charts/molgenis-jenkins/resources/tests/e2e-commander/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/e2e-commander/Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
         stage('Deploy [ e2e ]') {
             steps {
                 container('rancher') {
-                    sh "rancher context switch dev-molgenis"
                     sh "rancher apps install " +
                             "cattle-global-data:molgenis-helm-molgenis " +
                             "${TAG} " +
@@ -89,7 +88,6 @@ pipeline {
     post {
         always {
             container('rancher') {
-                sh "rancher context switch dev-molgenis"
                 sh "rancher apps delete ${TAG}"
             }
         }

--- a/charts/molgenis-jenkins/resources/tests/e2e/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/e2e/Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
         stage('Deploy [ e2e ]') {
             steps {
                 container('rancher') {
-                    sh "rancher context switch dev-molgenis"
                     sh "rancher apps install " +
                             "-n molgenis-${TAG} " +
                             "cattle-global-data:molgenis-helm-molgenis " +
@@ -163,7 +162,6 @@ pipeline {
     post {
         success {
             container('rancher') {
-                sh "rancher context switch dev-molgenis"
                 sh "rancher apps delete ${TAG}"
             }
         }

--- a/charts/molgenis-jenkins/resources/tests/live/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/live/Jenkinsfile
@@ -34,7 +34,6 @@ pipeline {
         stage('Deploy [ live ]') {
             steps {
                 container('rancher') {
-                    sh "rancher context switch dev-molgenis"
                     sh "rancher apps install " +
                             "-n molgenis-${TAG} " +
                             "cattle-global-data:molgenis-helm-molgenis " +
@@ -143,7 +142,6 @@ pipeline {
     post {
         success {
             container('rancher') {
-                sh "rancher context switch dev-molgenis"
                 sh "rancher apps delete ${TAG}"
             }
         }

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -148,7 +148,6 @@ jenkins:
                               sh(script: &apos;vault read -field=value secret/ops/jenkins/rancher/cli2.json &gt; /home/jenkins/.rancher/cli2.json&apos;)
                           }
                           container(&apos;rancher&apos;) {
-                              sh &quot;rancher context switch dev-molgenis&quot;
                               sh &quot;rancher app | awk &apos;{print \$2}&apos; | grep preview- &gt; preview.list&quot;
                               sh &quot;xargs rancher app delete &lt; preview.list&quot;
                           }


### PR DESCRIPTION
It is the default context already and switching currently is broken because there are
two contexts named molgenis-dev

#### Checklist
- [x] Functionality works & meets specifications (tested on rancher)
- [x] Templates reviewed
- [ ] Added values to questions
- [x] Bumped the chart version
- [ ] Updated appVersion (if needed)
