### PR TITLE
fix(frontend): simpler liveness and readiness probes

### DIFF
--- a/charts/molgenis-frontend/Chart.yaml
+++ b/charts/molgenis-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "8.1"
 description: MOLGENIS Helm chart for the frontend
 name: molgenis-frontend
-version: 1.1.4
+version: 1.1.5
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 icon: https://github.com/molgenis/molgenis-ops-helm/raw/master/charts/molgenis-frontend/catalogIcon-molgenis-frontend.png

--- a/charts/molgenis-frontend/templates/deployment.yaml
+++ b/charts/molgenis-frontend/templates/deployment.yaml
@@ -40,21 +40,12 @@ spec:
           resources:
 {{ toYaml .resources | nindent 12 }}
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 80
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            failureThreshold: 50
-            successThreshold: 1
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .readinessPath }}
               port: 80
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            failureThreshold: 3
-            successThreshold: 1
       volumes:
         - name: proxy-backend-config
           configMap:

--- a/charts/molgenis-frontend/values.yaml
+++ b/charts/molgenis-frontend/values.yaml
@@ -10,6 +10,8 @@ strategy:
   type: Recreate
 restartPolicy: Always
 
+readinessPath: '/@molgenis-ui/legacy-lib/dist/context.css'
+
 image:
   repository: registry.hub.docker.com
   name: molgenis/molgenis-frontend


### PR DESCRIPTION
Pinging on / is problematic since it's proxying the backend.
Make liveness a simple TCP port probe and readiness a check to see if a
small but vital resource is being served.

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
