### PR TITLE
feat(molgenis-frontend): allow basic auth security

### DIFF
--- a/charts/molgenis-frontend/Chart.yaml
+++ b/charts/molgenis-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "8.1"
 description: MOLGENIS Helm chart for the frontend
 name: molgenis-frontend
-version: 1.2.3
+version: 1.3.0
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 icon: https://github.com/molgenis/molgenis-ops-helm/raw/master/charts/molgenis-frontend/catalogIcon-molgenis-frontend.png

--- a/charts/molgenis-frontend/templates/basic-auth.yaml
+++ b/charts/molgenis-frontend/templates/basic-auth.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.ingress.basicAuth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth
+  labels:
+    app: {{ template "frontend.name" . }}
+    chart: {{ template "frontend.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+data:
+  auth: {{ .Values.ingress.basicAuth.auth | b64enc | quote }}
+{{- end }}

--- a/charts/molgenis-frontend/templates/ingress.yaml
+++ b/charts/molgenis-frontend/templates/ingress.yaml
@@ -17,6 +17,11 @@ metadata:
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- if .Values.ingress.basicAuth.enabled }}
+    nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingress.basicAuth.realm | quote }}
+    nginx.ingress.kubernetes.io/auth-secret: "basic-auth"
+    nginx.ingress.kubernetes.io/auth-type: "basic"
+    {{- end }}
 spec:
   rules:
     - host: {{ template "hostname" . }}

--- a/charts/molgenis-frontend/values.yaml
+++ b/charts/molgenis-frontend/values.yaml
@@ -76,6 +76,10 @@ ingress:
   path: /
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 0
+  basicAuth:
+    enabled: false
+    realm: "Authentication Required"
+    auth: "xxxx"
 
 resources: {}
 


### PR DESCRIPTION
For lifelines we manually added basic auth security to the deployment.
Here, add it to the frontend chart.
As followup, need to upgrade the frontend subchart in molgenis chart.

It would be nice to generate the secret's auth key from username and password values but the `htpasswd` tool is not very clear on how that works, looks like it involves salting and hashing so it's probably a bit much for the poor sprig library to do on its own.

As an example: `user:$apr1$l7C4YghF$3duSgjvZ5FUJEMrhHoscq.` represents username `user` and password `password`.

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
