### PR TITLE
feat(hubot): Add 'preview pr' command

### DIFF
--- a/charts/molgenis-hubot/Chart.yaml
+++ b/charts/molgenis-hubot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.0.1"
+appVersion: "0.1.9"
 description: A Hubot for MOLGENIS
 name: molgenis-hubot
 sources:

--- a/charts/molgenis-hubot/Chart.yaml
+++ b/charts/molgenis-hubot/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "0.0.1"
 description: A Hubot for MOLGENIS
 name: molgenis-hubot
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 home: https://hubot.github.com/
 icon: https://raw.githubusercontent.com/molgenis/molgenis-ops-helm/master/charts/molgenis-hubot/catalogIcon-molgenis-hubot.png
-version: 0.2.2
+version: 0.3.0
 maintainers:
 - name: fdlk
 - name: sidohaakma

--- a/charts/molgenis-hubot/values.yaml
+++ b/charts/molgenis-hubot/values.yaml
@@ -415,6 +415,7 @@ hubot:
         #   hubot preview list - Welke preview omgevingen staan er allemaal gedeployed
         #   hubot preview delete <tag> - Verwijder de preview environment voor deze tag
         #   hubot preview <tag> - Deploy een molgenis preview environment voor deze tag
+        #   hubot preview pr <pr_number> - Deploy een molgenis preview environment voor de laatste tag van een pull request
         #
         # Author:
         #   fdlk

--- a/charts/molgenis-hubot/values.yaml
+++ b/charts/molgenis-hubot/values.yaml
@@ -484,9 +484,32 @@ hubot:
             , ->
               msg.reply "Tag `#{tag}` kan ik niet vinden, en ook niets wat erop lijkt :thinking_face:"
 
+        installPullRequestPreview = (msg) ->
+          pr_number = msg.match[1].replace(/`/g, '')
+          tag_base = "PR-" + pr_number
+          searchRegistry msg, "q=#{tag_base}"
+          , (items) ->
+            tags = items.map (item) -> item.version
+            latest_pr_tag = null
+            highest_pr_tag_version = 0
+            for tag in tags
+              if tag.startsWith(tag_base + "-")
+                pr_tag_version = parseInt(tag.split("-").pop())
+                if pr_tag_version > highest_pr_tag_version
+                  latest_pr_tag = tag
+                  highest_pr_tag_version = pr_tag_version
+            if latest_pr_tag == null
+              msg.reply "Ik kon wel tags vinden maar niet iets waar je wat aan hebt :confused: `#{tags.join("`,`")}`"
+            else
+              runPreviewJob msg, "install", latest_pr_tag, ->
+                msg.reply "De laatste tag voor PR `#{pr_number}` is `#{latest_pr_tag}` en die ga ik voor je klaarzetten! :rocket: Let op: ik ruim het vannacht weer voor je op."
+          , ->
+            msg.reply "Ik kan geen enkele tag vinden voor PR `#{pr_number}` :sob:"
+
         module.exports = (robot) ->
           robot.respond /preview delete (.+)/i, (msg) -> deletePreview(msg)
           robot.respond /preview list/i, (msg) -> listPreview(msg)
+          robot.respond /preview pr (\d+)/i, (msg) -> installPullRequestPreview(msg)
           robot.respond /preview (?!delete|list)(.+)/i, (msg) -> installPreview(msg)
 
   ingress:

--- a/charts/molgenis-hubot/values.yaml
+++ b/charts/molgenis-hubot/values.yaml
@@ -511,7 +511,7 @@ hubot:
           robot.respond /preview delete (.+)/i, (msg) -> deletePreview(msg)
           robot.respond /preview list/i, (msg) -> listPreview(msg)
           robot.respond /preview pr (\d+)/i, (msg) -> installPullRequestPreview(msg)
-          robot.respond /preview (?!delete|list)(.+)/i, (msg) -> installPreview(msg)
+          robot.respond /preview tag (.+)/i, (msg) -> installPreview(msg)
 
   ingress:
     enabled: false


### PR DESCRIPTION
Adds a `pr` command that automatically finds the last tag of a pull request and previews it:

```
bot preview pr 2348
```

Other tags can still be used with the 'tag' syntax:

```
bot preview tag PR-2348-2
```

#### Checklist
- [x] Functionality works & meets specifications (tested on rancher)
- [x] Templates reviewed
- [x] Added values to questions
- [x] Bumped the chart version
- [x] Updated appVersion (if needed)
