### PR TITLE
fix(jenkins): drastically increase health probe timeouts

### DIFF
--- a/charts/molgenis-jenkins/Chart.yaml
+++ b/charts/molgenis-jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: molgenis-jenkins
 home: https://jenkins.io/
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.215
 description: Molgenis installation for the jenkins chart.
 sources:

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -49,6 +49,8 @@ jenkins:
         value: "ABCDEFG"
       - name: "GITHUB_ORG_NAME"
         value: "molgenis-jenkins"
+    healthProbeLivenessInitialDelay: 900
+    healthProbeReadinessInitialDelay: 600
     additionalConfig:
       org.thoughtslive.jenkins.plugins.hubot.config.GlobalConfig.xml: |-
         <?xml version='1.1' encoding='UTF-8'?>


### PR DESCRIPTION
The organisation scan needs to finish before the health checks begin to fail

#### Checklist
- [x] Functionality works & meets specifications (tested on rancher)
- [x] Templates reviewed
- Added values to questions
- [x] Bumped the chart version
- Updated appVersion (if needed)
