### PR TITLE
feat(fusion-auth): add molgenis blue theme

### DIFF
--- a/charts/fusion-auth/Chart.yaml
+++ b/charts/fusion-auth/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.15.8"
 description: Rancher wrapper around fusionauth chart
 name: fusion-auth
 home: https://fusionauth.io/
-version: 0.1.0
+version: 0.2.0
 icon: https://raw.githubusercontent.com/molgenis/molgenis-ops-helm/master/charts/fusion-auth/fusion-auth.png
 maintainers:
 - name: fdlk

--- a/charts/fusion-auth/questions.yml
+++ b/charts/fusion-auth/questions.yml
@@ -11,3 +11,7 @@ questions:
     label: Image tag
     required: true
     default: "1.15.8"
+  - variable: fusionauth.environment.FUSIONAUTH_API_KEY
+    type: password
+    label: API Key
+    required: true

--- a/charts/fusion-auth/values.yaml
+++ b/charts/fusion-auth/values.yaml
@@ -1,4 +1,10369 @@
 fusionauth:
+  environment:
+    FUSIONAUTH_MEMORY: 256M
+    FUSIONAUTH_KICKSTART: /kickstart/kickstart.json
+    FUSIONAUTH_API_KEY: "NLNH0X2cuVYKYKIRwl2u7eYZeKi5riBv7Jk4ytIp2PA"
+  kickstart:
+    enabled: true
+    data:
+      kickstart.json: |-
+        {
+          "variables": {
+            "defaultThemeId": "75a068fd-e94b-451a-9aeb-3ddb9a3b5987",
+            "molgenisThemeId": "05c230a2-a05a-47cf-aecb-690a4dd38884",
+            "apiKey": "#{ENV.FUSIONAUTH_API_KEY}"
+          },
+          "apiKeys": [
+            {
+              "key": "#{apiKey}",
+              "description": "Core API Key"
+            }
+          ],
+          "requests": [{
+            "method": "POST",
+            "url": "/api/theme/#{molgenisThemeId}",
+            "body": {
+              "sourceThemeId": "#{defaultThemeId}",
+              "theme": {
+                "name": "MOLGENIS Blue"
+              }
+            }
+          }, {
+            "method": "PATCH",
+            "url": "/api/theme/#{molgenisThemeId}",
+            "body": {
+              "theme": {
+                "templates": {
+                  "helpers": "@{helpers.ftl}",
+                  "oauth2Authorize": "@{oauth2Authorize.ftl}",
+                  "oauth2Logout": "@{oauth2Logout.ftl}"
+                },
+                "stylesheet": "@{molgenis-blue.css}"
+              }
+            }
+          }]
+        }
+      molgenis-blue.css: |-
+        .logo-top {
+          max-width: 50%;
+          padding-top: 30px;
+          align-self: center;
+        }
+
+        .table,
+        .list-group-item {
+          font-family: "IBM Plex Mono", monospace;
+        }
+
+        .navbar {
+          font-weight: 600;
+          box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.05), 0 2px 2px 0 rgba(0, 0, 0, 0.05);
+        }
+
+
+        /*!
+        * Bootstrap v4.2.1 (https://getbootstrap.com/)
+        * Copyright 2011-2018 The Bootstrap Authors
+        * Copyright 2011-2018 Twitter, Inc.
+        * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+        */
+
+        :root {
+          --blue: #007bff;
+          --indigo: #6610f2;
+          --purple: #6f42c1;
+          --pink: #e83e8c;
+          --red: #F36969;
+          --orange: #fd7e14;
+          --yellow: #ffc107;
+          --green: #28a745;
+          --teal: #20c997;
+          --cyan: #17a2b8;
+          --white: #FFFFFF;
+          --gray: #6c757d;
+          --gray-dark: #343a40;
+          --primary: #017FFD;
+          --secondary: #005EC4;
+          --success: #00BD55;
+          --info: #17a2b8;
+          --warning: #ffc107;
+          --danger: #F36969;
+          --light: #FFFFFF;
+          --dark: #353535;
+          --breakpoint-xs: 0;
+          --breakpoint-sm: 576px;
+          --breakpoint-md: 768px;
+          --breakpoint-lg: 992px;
+          --breakpoint-xl: 1200px;
+          --font-family-sans-serif: 'IBM Plex Sans';
+          --font-family-monospace: 'IBM Plex Mono';
+        }
+
+        *,
+        *::before,
+        *::after {
+          box-sizing: border-box;
+        }
+
+        html {
+          font-family: sans-serif;
+          line-height: 1.15;
+          -webkit-text-size-adjust: 100%;
+          -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+        }
+
+        article,
+        aside,
+        figcaption,
+        figure,
+        footer,
+        header,
+        hgroup,
+        main,
+        nav,
+        section {
+          display: block;
+        }
+
+        body {
+          margin: 0;
+          font-family: "IBM Plex Sans";
+          font-size: 1rem;
+          font-weight: 400;
+          line-height: 1.5;
+          color: #212529;
+          text-align: left;
+          background-color: #fafafa;
+        }
+
+        [tabindex="-1"]:focus {
+          outline: 0 !important;
+        }
+
+        hr {
+          box-sizing: content-box;
+          height: 0;
+          overflow: visible;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+          margin-top: 0;
+          margin-bottom: 0.5rem;
+        }
+
+        p {
+          margin-top: 0;
+          margin-bottom: 1rem;
+        }
+
+        abbr[title],
+        abbr[data-original-title] {
+          text-decoration: underline;
+          -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
+          cursor: help;
+          border-bottom: 0;
+          text-decoration-skip-ink: none;
+        }
+
+        address {
+          margin-bottom: 1rem;
+          font-style: normal;
+          line-height: inherit;
+        }
+
+        ol,
+        ul,
+        dl {
+          margin-top: 0;
+          margin-bottom: 1rem;
+        }
+
+        ol ol,
+        ul ul,
+        ol ul,
+        ul ol {
+          margin-bottom: 0;
+        }
+
+        dt {
+          font-weight: 700;
+        }
+
+        dd {
+          margin-bottom: .5rem;
+          margin-left: 0;
+        }
+
+        blockquote {
+          margin: 0 0 1rem;
+        }
+
+        b,
+        strong {
+          font-weight: bolder;
+        }
+
+        small {
+          font-size: 80%;
+        }
+
+        sub,
+        sup {
+          position: relative;
+          font-size: 75%;
+          line-height: 0;
+          vertical-align: baseline;
+        }
+
+        sub {
+          bottom: -.25em;
+        }
+
+        sup {
+          top: -.5em;
+        }
+
+        a {
+          color: #017FFD;
+          text-decoration: none;
+          background-color: transparent;
+        }
+
+        a:hover {
+          color: #0159b1;
+          text-decoration: underline;
+        }
+
+        a:not([href]):not([tabindex]) {
+          color: inherit;
+          text-decoration: none;
+        }
+
+        a:not([href]):not([tabindex]):hover,
+        a:not([href]):not([tabindex]):focus {
+          color: inherit;
+          text-decoration: none;
+        }
+
+        a:not([href]):not([tabindex]):focus {
+          outline: 0;
+        }
+
+        pre,
+        code,
+        kbd,
+        samp {
+          font-family: "IBM Plex Mono";
+          font-size: 1em;
+        }
+
+        pre {
+          margin-top: 0;
+          margin-bottom: 1rem;
+          overflow: auto;
+        }
+
+        figure {
+          margin: 0 0 1rem;
+        }
+
+        img {
+          vertical-align: middle;
+          border-style: none;
+        }
+
+        svg {
+          overflow: hidden;
+          vertical-align: middle;
+        }
+
+        table {
+          border-collapse: collapse;
+        }
+
+        caption {
+          padding-top: 0.75rem;
+          padding-bottom: 0.75rem;
+          color: #6c757d;
+          text-align: left;
+          caption-side: bottom;
+        }
+
+        th {
+          text-align: inherit;
+        }
+
+        label {
+          display: inline-block;
+          margin-bottom: 0.5rem;
+        }
+
+        button {
+          border-radius: 0;
+        }
+
+        button:focus {
+          outline: 1px dotted;
+          outline: 5px auto -webkit-focus-ring-color;
+        }
+
+        input,
+        button,
+        select,
+        optgroup,
+        textarea {
+          margin: 0;
+          font-family: inherit;
+          font-size: inherit;
+          line-height: inherit;
+        }
+
+        button,
+        input {
+          overflow: visible;
+        }
+
+        button,
+        select {
+          text-transform: none;
+        }
+
+        button,
+        [type="button"],
+        [type="reset"],
+        [type="submit"] {
+          -webkit-appearance: button;
+        }
+
+        button::-moz-focus-inner,
+        [type="button"]::-moz-focus-inner,
+        [type="reset"]::-moz-focus-inner,
+        [type="submit"]::-moz-focus-inner {
+          padding: 0;
+          border-style: none;
+        }
+
+        input[type="radio"],
+        input[type="checkbox"] {
+          box-sizing: border-box;
+          padding: 0;
+        }
+
+        input[type="date"],
+        input[type="time"],
+        input[type="datetime-local"],
+        input[type="month"] {
+          -webkit-appearance: listbox;
+        }
+
+        textarea {
+          overflow: auto;
+          resize: vertical;
+        }
+
+        fieldset {
+          min-width: 0;
+          padding: 0;
+          margin: 0;
+          border: 0;
+        }
+
+        legend {
+          display: block;
+          width: 100%;
+          max-width: 100%;
+          padding: 0;
+          margin-bottom: .5rem;
+          font-size: 1.5rem;
+          line-height: inherit;
+          color: inherit;
+          white-space: normal;
+        }
+
+        progress {
+          vertical-align: baseline;
+        }
+
+        [type="number"]::-webkit-inner-spin-button,
+        [type="number"]::-webkit-outer-spin-button {
+          height: auto;
+        }
+
+        [type="search"] {
+          outline-offset: -2px;
+          -webkit-appearance: none;
+        }
+
+        [type="search"]::-webkit-search-decoration {
+          -webkit-appearance: none;
+        }
+
+        ::-webkit-file-upload-button {
+          font: inherit;
+          -webkit-appearance: button;
+        }
+
+        output {
+          display: inline-block;
+        }
+
+        summary {
+          display: list-item;
+          cursor: pointer;
+        }
+
+        template {
+          display: none;
+        }
+
+        [hidden] {
+          display: none !important;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        .h1,
+        .h2,
+        .h3,
+        .h4,
+        .h5,
+        .h6 {
+          margin-bottom: 0.5rem;
+          font-family: "Bebas Neue";
+          font-weight: 500;
+          line-height: 1.2;
+          color: inherit;
+        }
+
+        h1,
+        .h1 {
+          font-size: 2.5rem;
+        }
+
+        h2,
+        .h2 {
+          font-size: 2rem;
+        }
+
+        h3,
+        .h3 {
+          font-size: 1.75rem;
+        }
+
+        h4,
+        .h4 {
+          font-size: 1.5rem;
+        }
+
+        h5,
+        .h5 {
+          font-size: 1.25rem;
+        }
+
+        h6,
+        .h6 {
+          font-size: 1rem;
+        }
+
+        .lead {
+          font-size: 1.25rem;
+          font-weight: 300;
+        }
+
+        .display-1 {
+          font-size: 6rem;
+          font-weight: 300;
+          line-height: 1.2;
+        }
+
+        .display-2 {
+          font-size: 5.5rem;
+          font-weight: 300;
+          line-height: 1.2;
+        }
+
+        .display-3 {
+          font-size: 4.5rem;
+          font-weight: 300;
+          line-height: 1.2;
+        }
+
+        .display-4 {
+          font-size: 3.5rem;
+          font-weight: 300;
+          line-height: 1.2;
+        }
+
+        hr {
+          margin-top: 1rem;
+          margin-bottom: 1rem;
+          border: 0;
+          border-top: 1px solid rgba(0, 0, 0, 0.1);
+        }
+
+        small,
+        .small {
+          font-size: 80%;
+          font-weight: 400;
+        }
+
+        mark,
+        .mark {
+          padding: 0.2em;
+          background-color: #fcf8e3;
+        }
+
+        .list-unstyled {
+          padding-left: 0;
+          list-style: none;
+        }
+
+        .list-inline {
+          padding-left: 0;
+          list-style: none;
+        }
+
+        .list-inline-item {
+          display: inline-block;
+        }
+
+        .list-inline-item:not(:last-child) {
+          margin-right: 0.5rem;
+        }
+
+        .initialism {
+          font-size: 90%;
+          text-transform: uppercase;
+        }
+
+        .blockquote {
+          margin-bottom: 1rem;
+          font-size: 1.25rem;
+        }
+
+        .blockquote-footer {
+          display: block;
+          font-size: 80%;
+          color: #6c757d;
+        }
+
+        .blockquote-footer::before {
+          content: "\2014\00A0";
+        }
+
+        .img-fluid {
+          max-width: 100%;
+          height: auto;
+        }
+
+        .img-thumbnail {
+          padding: 0.25rem;
+          background-color: #fafafa;
+          border: 1px solid #dee2e6;
+          border-radius: 0px;
+          max-width: 100%;
+          height: auto;
+        }
+
+        .figure {
+          display: inline-block;
+        }
+
+        .figure-img {
+          margin-bottom: 0.5rem;
+          line-height: 1;
+        }
+
+        .figure-caption {
+          font-size: 90%;
+          color: #6c757d;
+        }
+
+        code {
+          font-size: 87.5%;
+          color: #e83e8c;
+          word-break: break-word;
+        }
+
+        a>code {
+          color: inherit;
+        }
+
+        kbd {
+          padding: 0.2rem 0.4rem;
+          font-size: 87.5%;
+          color: #FFFFFF;
+          background-color: #212529;
+          border-radius: 0.2rem;
+        }
+
+        kbd kbd {
+          padding: 0;
+          font-size: 100%;
+          font-weight: 700;
+        }
+
+        pre {
+          display: block;
+          font-size: 87.5%;
+          color: #212529;
+        }
+
+        pre code {
+          font-size: inherit;
+          color: inherit;
+          word-break: normal;
+        }
+
+        .pre-scrollable {
+          max-height: 340px;
+          overflow-y: scroll;
+        }
+
+        .container {
+          width: 100%;
+          padding-right: 15px;
+          padding-left: 15px;
+          margin-right: auto;
+          margin-left: auto;
+        }
+
+        @media (min-width: 576px) {
+          .container {
+            max-width: 540px;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .container {
+            max-width: 720px;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .container {
+            max-width: 960px;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .container {
+            max-width: 1140px;
+          }
+        }
+
+        .container-fluid {
+          width: 100%;
+          padding-right: 15px;
+          padding-left: 15px;
+          margin-right: auto;
+          margin-left: auto;
+        }
+
+        .row {
+          display: flex;
+          flex-wrap: wrap;
+          margin-right: -15px;
+          margin-left: -15px;
+        }
+
+        .no-gutters {
+          margin-right: 0;
+          margin-left: 0;
+        }
+
+        .no-gutters>.col,
+        .no-gutters>[class*="col-"] {
+          padding-right: 0;
+          padding-left: 0;
+        }
+
+        .col-1,
+        .col-2,
+        .col-3,
+        .col-4,
+        .col-5,
+        .col-6,
+        .col-7,
+        .col-8,
+        .col-9,
+        .col-10,
+        .col-11,
+        .col-12,
+        .col,
+        .col-auto,
+        .col-sm-1,
+        .col-sm-2,
+        .col-sm-3,
+        .col-sm-4,
+        .col-sm-5,
+        .col-sm-6,
+        .col-sm-7,
+        .col-sm-8,
+        .col-sm-9,
+        .col-sm-10,
+        .col-sm-11,
+        .col-sm-12,
+        .col-sm,
+        .col-sm-auto,
+        .col-md-1,
+        .col-md-2,
+        .col-md-3,
+        .col-md-4,
+        .col-md-5,
+        .col-md-6,
+        .col-md-7,
+        .col-md-8,
+        .col-md-9,
+        .col-md-10,
+        .col-md-11,
+        .col-md-12,
+        .col-md,
+        .col-md-auto,
+        .col-lg-1,
+        .col-lg-2,
+        .col-lg-3,
+        .col-lg-4,
+        .col-lg-5,
+        .col-lg-6,
+        .col-lg-7,
+        .col-lg-8,
+        .col-lg-9,
+        .col-lg-10,
+        .col-lg-11,
+        .col-lg-12,
+        .col-lg,
+        .col-lg-auto,
+        .col-xl-1,
+        .col-xl-2,
+        .col-xl-3,
+        .col-xl-4,
+        .col-xl-5,
+        .col-xl-6,
+        .col-xl-7,
+        .col-xl-8,
+        .col-xl-9,
+        .col-xl-10,
+        .col-xl-11,
+        .col-xl-12,
+        .col-xl,
+        .col-xl-auto {
+          position: relative;
+          width: 100%;
+          padding-right: 15px;
+          padding-left: 15px;
+        }
+
+        .col {
+          flex-basis: 0;
+          flex-grow: 1;
+          max-width: 100%;
+        }
+
+        .col-auto {
+          flex: 0 0 auto;
+          width: auto;
+          max-width: 100%;
+        }
+
+        .col-1 {
+          flex: 0 0 8.33333%;
+          max-width: 8.33333%;
+        }
+
+        .col-2 {
+          flex: 0 0 16.66667%;
+          max-width: 16.66667%;
+        }
+
+        .col-3 {
+          flex: 0 0 25%;
+          max-width: 25%;
+        }
+
+        .col-4 {
+          flex: 0 0 33.33333%;
+          max-width: 33.33333%;
+        }
+
+        .col-5 {
+          flex: 0 0 41.66667%;
+          max-width: 41.66667%;
+        }
+
+        .col-6 {
+          flex: 0 0 50%;
+          max-width: 50%;
+        }
+
+        .col-7 {
+          flex: 0 0 58.33333%;
+          max-width: 58.33333%;
+        }
+
+        .col-8 {
+          flex: 0 0 66.66667%;
+          max-width: 66.66667%;
+        }
+
+        .col-9 {
+          flex: 0 0 75%;
+          max-width: 75%;
+        }
+
+        .col-10 {
+          flex: 0 0 83.33333%;
+          max-width: 83.33333%;
+        }
+
+        .col-11 {
+          flex: 0 0 91.66667%;
+          max-width: 91.66667%;
+        }
+
+        .col-12 {
+          flex: 0 0 100%;
+          max-width: 100%;
+        }
+
+        .order-first {
+          order: -1;
+        }
+
+        .order-last {
+          order: 13;
+        }
+
+        .order-0 {
+          order: 0;
+        }
+
+        .order-1 {
+          order: 1;
+        }
+
+        .order-2 {
+          order: 2;
+        }
+
+        .order-3 {
+          order: 3;
+        }
+
+        .order-4 {
+          order: 4;
+        }
+
+        .order-5 {
+          order: 5;
+        }
+
+        .order-6 {
+          order: 6;
+        }
+
+        .order-7 {
+          order: 7;
+        }
+
+        .order-8 {
+          order: 8;
+        }
+
+        .order-9 {
+          order: 9;
+        }
+
+        .order-10 {
+          order: 10;
+        }
+
+        .order-11 {
+          order: 11;
+        }
+
+        .order-12 {
+          order: 12;
+        }
+
+        .offset-1 {
+          margin-left: 8.33333%;
+        }
+
+        .offset-2 {
+          margin-left: 16.66667%;
+        }
+
+        .offset-3 {
+          margin-left: 25%;
+        }
+
+        .offset-4 {
+          margin-left: 33.33333%;
+        }
+
+        .offset-5 {
+          margin-left: 41.66667%;
+        }
+
+        .offset-6 {
+          margin-left: 50%;
+        }
+
+        .offset-7 {
+          margin-left: 58.33333%;
+        }
+
+        .offset-8 {
+          margin-left: 66.66667%;
+        }
+
+        .offset-9 {
+          margin-left: 75%;
+        }
+
+        .offset-10 {
+          margin-left: 83.33333%;
+        }
+
+        .offset-11 {
+          margin-left: 91.66667%;
+        }
+
+        @media (min-width: 576px) {
+          .col-sm {
+            flex-basis: 0;
+            flex-grow: 1;
+            max-width: 100%;
+          }
+          .col-sm-auto {
+            flex: 0 0 auto;
+            width: auto;
+            max-width: 100%;
+          }
+          .col-sm-1 {
+            flex: 0 0 8.33333%;
+            max-width: 8.33333%;
+          }
+          .col-sm-2 {
+            flex: 0 0 16.66667%;
+            max-width: 16.66667%;
+          }
+          .col-sm-3 {
+            flex: 0 0 25%;
+            max-width: 25%;
+          }
+          .col-sm-4 {
+            flex: 0 0 33.33333%;
+            max-width: 33.33333%;
+          }
+          .col-sm-5 {
+            flex: 0 0 41.66667%;
+            max-width: 41.66667%;
+          }
+          .col-sm-6 {
+            flex: 0 0 50%;
+            max-width: 50%;
+          }
+          .col-sm-7 {
+            flex: 0 0 58.33333%;
+            max-width: 58.33333%;
+          }
+          .col-sm-8 {
+            flex: 0 0 66.66667%;
+            max-width: 66.66667%;
+          }
+          .col-sm-9 {
+            flex: 0 0 75%;
+            max-width: 75%;
+          }
+          .col-sm-10 {
+            flex: 0 0 83.33333%;
+            max-width: 83.33333%;
+          }
+          .col-sm-11 {
+            flex: 0 0 91.66667%;
+            max-width: 91.66667%;
+          }
+          .col-sm-12 {
+            flex: 0 0 100%;
+            max-width: 100%;
+          }
+          .order-sm-first {
+            order: -1;
+          }
+          .order-sm-last {
+            order: 13;
+          }
+          .order-sm-0 {
+            order: 0;
+          }
+          .order-sm-1 {
+            order: 1;
+          }
+          .order-sm-2 {
+            order: 2;
+          }
+          .order-sm-3 {
+            order: 3;
+          }
+          .order-sm-4 {
+            order: 4;
+          }
+          .order-sm-5 {
+            order: 5;
+          }
+          .order-sm-6 {
+            order: 6;
+          }
+          .order-sm-7 {
+            order: 7;
+          }
+          .order-sm-8 {
+            order: 8;
+          }
+          .order-sm-9 {
+            order: 9;
+          }
+          .order-sm-10 {
+            order: 10;
+          }
+          .order-sm-11 {
+            order: 11;
+          }
+          .order-sm-12 {
+            order: 12;
+          }
+          .offset-sm-0 {
+            margin-left: 0;
+          }
+          .offset-sm-1 {
+            margin-left: 8.33333%;
+          }
+          .offset-sm-2 {
+            margin-left: 16.66667%;
+          }
+          .offset-sm-3 {
+            margin-left: 25%;
+          }
+          .offset-sm-4 {
+            margin-left: 33.33333%;
+          }
+          .offset-sm-5 {
+            margin-left: 41.66667%;
+          }
+          .offset-sm-6 {
+            margin-left: 50%;
+          }
+          .offset-sm-7 {
+            margin-left: 58.33333%;
+          }
+          .offset-sm-8 {
+            margin-left: 66.66667%;
+          }
+          .offset-sm-9 {
+            margin-left: 75%;
+          }
+          .offset-sm-10 {
+            margin-left: 83.33333%;
+          }
+          .offset-sm-11 {
+            margin-left: 91.66667%;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .col-md {
+            flex-basis: 0;
+            flex-grow: 1;
+            max-width: 100%;
+          }
+          .col-md-auto {
+            flex: 0 0 auto;
+            width: auto;
+            max-width: 100%;
+          }
+          .col-md-1 {
+            flex: 0 0 8.33333%;
+            max-width: 8.33333%;
+          }
+          .col-md-2 {
+            flex: 0 0 16.66667%;
+            max-width: 16.66667%;
+          }
+          .col-md-3 {
+            flex: 0 0 25%;
+            max-width: 25%;
+          }
+          .col-md-4 {
+            flex: 0 0 33.33333%;
+            max-width: 33.33333%;
+          }
+          .col-md-5 {
+            flex: 0 0 41.66667%;
+            max-width: 41.66667%;
+          }
+          .col-md-6 {
+            flex: 0 0 50%;
+            max-width: 50%;
+          }
+          .col-md-7 {
+            flex: 0 0 58.33333%;
+            max-width: 58.33333%;
+          }
+          .col-md-8 {
+            flex: 0 0 66.66667%;
+            max-width: 66.66667%;
+          }
+          .col-md-9 {
+            flex: 0 0 75%;
+            max-width: 75%;
+          }
+          .col-md-10 {
+            flex: 0 0 83.33333%;
+            max-width: 83.33333%;
+          }
+          .col-md-11 {
+            flex: 0 0 91.66667%;
+            max-width: 91.66667%;
+          }
+          .col-md-12 {
+            flex: 0 0 100%;
+            max-width: 100%;
+          }
+          .order-md-first {
+            order: -1;
+          }
+          .order-md-last {
+            order: 13;
+          }
+          .order-md-0 {
+            order: 0;
+          }
+          .order-md-1 {
+            order: 1;
+          }
+          .order-md-2 {
+            order: 2;
+          }
+          .order-md-3 {
+            order: 3;
+          }
+          .order-md-4 {
+            order: 4;
+          }
+          .order-md-5 {
+            order: 5;
+          }
+          .order-md-6 {
+            order: 6;
+          }
+          .order-md-7 {
+            order: 7;
+          }
+          .order-md-8 {
+            order: 8;
+          }
+          .order-md-9 {
+            order: 9;
+          }
+          .order-md-10 {
+            order: 10;
+          }
+          .order-md-11 {
+            order: 11;
+          }
+          .order-md-12 {
+            order: 12;
+          }
+          .offset-md-0 {
+            margin-left: 0;
+          }
+          .offset-md-1 {
+            margin-left: 8.33333%;
+          }
+          .offset-md-2 {
+            margin-left: 16.66667%;
+          }
+          .offset-md-3 {
+            margin-left: 25%;
+          }
+          .offset-md-4 {
+            margin-left: 33.33333%;
+          }
+          .offset-md-5 {
+            margin-left: 41.66667%;
+          }
+          .offset-md-6 {
+            margin-left: 50%;
+          }
+          .offset-md-7 {
+            margin-left: 58.33333%;
+          }
+          .offset-md-8 {
+            margin-left: 66.66667%;
+          }
+          .offset-md-9 {
+            margin-left: 75%;
+          }
+          .offset-md-10 {
+            margin-left: 83.33333%;
+          }
+          .offset-md-11 {
+            margin-left: 91.66667%;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .col-lg {
+            flex-basis: 0;
+            flex-grow: 1;
+            max-width: 100%;
+          }
+          .col-lg-auto {
+            flex: 0 0 auto;
+            width: auto;
+            max-width: 100%;
+          }
+          .col-lg-1 {
+            flex: 0 0 8.33333%;
+            max-width: 8.33333%;
+          }
+          .col-lg-2 {
+            flex: 0 0 16.66667%;
+            max-width: 16.66667%;
+          }
+          .col-lg-3 {
+            flex: 0 0 25%;
+            max-width: 25%;
+          }
+          .col-lg-4 {
+            flex: 0 0 33.33333%;
+            max-width: 33.33333%;
+          }
+          .col-lg-5 {
+            flex: 0 0 41.66667%;
+            max-width: 41.66667%;
+          }
+          .col-lg-6 {
+            flex: 0 0 50%;
+            max-width: 50%;
+          }
+          .col-lg-7 {
+            flex: 0 0 58.33333%;
+            max-width: 58.33333%;
+          }
+          .col-lg-8 {
+            flex: 0 0 66.66667%;
+            max-width: 66.66667%;
+          }
+          .col-lg-9 {
+            flex: 0 0 75%;
+            max-width: 75%;
+          }
+          .col-lg-10 {
+            flex: 0 0 83.33333%;
+            max-width: 83.33333%;
+          }
+          .col-lg-11 {
+            flex: 0 0 91.66667%;
+            max-width: 91.66667%;
+          }
+          .col-lg-12 {
+            flex: 0 0 100%;
+            max-width: 100%;
+          }
+          .order-lg-first {
+            order: -1;
+          }
+          .order-lg-last {
+            order: 13;
+          }
+          .order-lg-0 {
+            order: 0;
+          }
+          .order-lg-1 {
+            order: 1;
+          }
+          .order-lg-2 {
+            order: 2;
+          }
+          .order-lg-3 {
+            order: 3;
+          }
+          .order-lg-4 {
+            order: 4;
+          }
+          .order-lg-5 {
+            order: 5;
+          }
+          .order-lg-6 {
+            order: 6;
+          }
+          .order-lg-7 {
+            order: 7;
+          }
+          .order-lg-8 {
+            order: 8;
+          }
+          .order-lg-9 {
+            order: 9;
+          }
+          .order-lg-10 {
+            order: 10;
+          }
+          .order-lg-11 {
+            order: 11;
+          }
+          .order-lg-12 {
+            order: 12;
+          }
+          .offset-lg-0 {
+            margin-left: 0;
+          }
+          .offset-lg-1 {
+            margin-left: 8.33333%;
+          }
+          .offset-lg-2 {
+            margin-left: 16.66667%;
+          }
+          .offset-lg-3 {
+            margin-left: 25%;
+          }
+          .offset-lg-4 {
+            margin-left: 33.33333%;
+          }
+          .offset-lg-5 {
+            margin-left: 41.66667%;
+          }
+          .offset-lg-6 {
+            margin-left: 50%;
+          }
+          .offset-lg-7 {
+            margin-left: 58.33333%;
+          }
+          .offset-lg-8 {
+            margin-left: 66.66667%;
+          }
+          .offset-lg-9 {
+            margin-left: 75%;
+          }
+          .offset-lg-10 {
+            margin-left: 83.33333%;
+          }
+          .offset-lg-11 {
+            margin-left: 91.66667%;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .col-xl {
+            flex-basis: 0;
+            flex-grow: 1;
+            max-width: 100%;
+          }
+          .col-xl-auto {
+            flex: 0 0 auto;
+            width: auto;
+            max-width: 100%;
+          }
+          .col-xl-1 {
+            flex: 0 0 8.33333%;
+            max-width: 8.33333%;
+          }
+          .col-xl-2 {
+            flex: 0 0 16.66667%;
+            max-width: 16.66667%;
+          }
+          .col-xl-3 {
+            flex: 0 0 25%;
+            max-width: 25%;
+          }
+          .col-xl-4 {
+            flex: 0 0 33.33333%;
+            max-width: 33.33333%;
+          }
+          .col-xl-5 {
+            flex: 0 0 41.66667%;
+            max-width: 41.66667%;
+          }
+          .col-xl-6 {
+            flex: 0 0 50%;
+            max-width: 50%;
+          }
+          .col-xl-7 {
+            flex: 0 0 58.33333%;
+            max-width: 58.33333%;
+          }
+          .col-xl-8 {
+            flex: 0 0 66.66667%;
+            max-width: 66.66667%;
+          }
+          .col-xl-9 {
+            flex: 0 0 75%;
+            max-width: 75%;
+          }
+          .col-xl-10 {
+            flex: 0 0 83.33333%;
+            max-width: 83.33333%;
+          }
+          .col-xl-11 {
+            flex: 0 0 91.66667%;
+            max-width: 91.66667%;
+          }
+          .col-xl-12 {
+            flex: 0 0 100%;
+            max-width: 100%;
+          }
+          .order-xl-first {
+            order: -1;
+          }
+          .order-xl-last {
+            order: 13;
+          }
+          .order-xl-0 {
+            order: 0;
+          }
+          .order-xl-1 {
+            order: 1;
+          }
+          .order-xl-2 {
+            order: 2;
+          }
+          .order-xl-3 {
+            order: 3;
+          }
+          .order-xl-4 {
+            order: 4;
+          }
+          .order-xl-5 {
+            order: 5;
+          }
+          .order-xl-6 {
+            order: 6;
+          }
+          .order-xl-7 {
+            order: 7;
+          }
+          .order-xl-8 {
+            order: 8;
+          }
+          .order-xl-9 {
+            order: 9;
+          }
+          .order-xl-10 {
+            order: 10;
+          }
+          .order-xl-11 {
+            order: 11;
+          }
+          .order-xl-12 {
+            order: 12;
+          }
+          .offset-xl-0 {
+            margin-left: 0;
+          }
+          .offset-xl-1 {
+            margin-left: 8.33333%;
+          }
+          .offset-xl-2 {
+            margin-left: 16.66667%;
+          }
+          .offset-xl-3 {
+            margin-left: 25%;
+          }
+          .offset-xl-4 {
+            margin-left: 33.33333%;
+          }
+          .offset-xl-5 {
+            margin-left: 41.66667%;
+          }
+          .offset-xl-6 {
+            margin-left: 50%;
+          }
+          .offset-xl-7 {
+            margin-left: 58.33333%;
+          }
+          .offset-xl-8 {
+            margin-left: 66.66667%;
+          }
+          .offset-xl-9 {
+            margin-left: 75%;
+          }
+          .offset-xl-10 {
+            margin-left: 83.33333%;
+          }
+          .offset-xl-11 {
+            margin-left: 91.66667%;
+          }
+        }
+
+        .table {
+          width: 100%;
+          margin-bottom: 1rem;
+          background-color: #FFFFFF;
+        }
+
+        .table th,
+        .table td {
+          padding: 0.75rem;
+          vertical-align: top;
+          border-top: 1px solid #dee2e6;
+        }
+
+        .table thead th {
+          vertical-align: bottom;
+          border-bottom: 2px solid #dee2e6;
+        }
+
+        .table tbody+tbody {
+          border-top: 2px solid #dee2e6;
+        }
+
+        .table .table {
+          background-color: #fafafa;
+        }
+
+        .table-sm th,
+        .table-sm td {
+          padding: 0.3rem;
+        }
+
+        .table-bordered {
+          border: 1px solid #dee2e6;
+        }
+
+        .table-bordered th,
+        .table-bordered td {
+          border: 1px solid #dee2e6;
+        }
+
+        .table-bordered thead th,
+        .table-bordered thead td {
+          border-bottom-width: 2px;
+        }
+
+        .table-borderless th,
+        .table-borderless td,
+        .table-borderless thead th,
+        .table-borderless tbody+tbody {
+          border: 0;
+        }
+
+        .table-striped tbody tr:nth-of-type(odd) {
+          background-color: rgba(0, 0, 0, 0.05);
+        }
+
+        .table-hover tbody tr:hover {
+          background-color: rgba(0, 0, 0, 0.075);
+        }
+
+        .table-primary,
+        .table-primary>th,
+        .table-primary>td {
+          background-color: #b8dbfe;
+        }
+
+        .table-primary th,
+        .table-primary td,
+        .table-primary thead th,
+        .table-primary tbody+tbody {
+          border-color: #7bbcfe;
+        }
+
+        .table-hover .table-primary:hover {
+          background-color: #9fcefe;
+        }
+
+        .table-hover .table-primary:hover>td,
+        .table-hover .table-primary:hover>th {
+          background-color: #9fcefe;
+        }
+
+        .table-secondary,
+        .table-secondary>th,
+        .table-secondary>td {
+          background-color: #b8d2ee;
+        }
+
+        .table-secondary th,
+        .table-secondary td,
+        .table-secondary thead th,
+        .table-secondary tbody+tbody {
+          border-color: #7aabe0;
+        }
+
+        .table-hover .table-secondary:hover {
+          background-color: #a3c5e9;
+        }
+
+        .table-hover .table-secondary:hover>td,
+        .table-hover .table-secondary:hover>th {
+          background-color: #a3c5e9;
+        }
+
+        .table-success,
+        .table-success>th,
+        .table-success>td {
+          background-color: #b8edcf;
+        }
+
+        .table-success th,
+        .table-success td,
+        .table-success thead th,
+        .table-success tbody+tbody {
+          border-color: #7adda7;
+        }
+
+        .table-hover .table-success:hover {
+          background-color: #a4e8c1;
+        }
+
+        .table-hover .table-success:hover>td,
+        .table-hover .table-success:hover>th {
+          background-color: #a4e8c1;
+        }
+
+        .table-info,
+        .table-info>th,
+        .table-info>td {
+          background-color: #bee5eb;
+        }
+
+        .table-info th,
+        .table-info td,
+        .table-info thead th,
+        .table-info tbody+tbody {
+          border-color: #86cfda;
+        }
+
+        .table-hover .table-info:hover {
+          background-color: #abdde5;
+        }
+
+        .table-hover .table-info:hover>td,
+        .table-hover .table-info:hover>th {
+          background-color: #abdde5;
+        }
+
+        .table-warning,
+        .table-warning>th,
+        .table-warning>td {
+          background-color: #ffeeba;
+        }
+
+        .table-warning th,
+        .table-warning td,
+        .table-warning thead th,
+        .table-warning tbody+tbody {
+          border-color: #ffdf7e;
+        }
+
+        .table-hover .table-warning:hover {
+          background-color: #ffe8a1;
+        }
+
+        .table-hover .table-warning:hover>td,
+        .table-hover .table-warning:hover>th {
+          background-color: #ffe8a1;
+        }
+
+        .table-danger,
+        .table-danger>th,
+        .table-danger>td {
+          background-color: #fcd5d5;
+        }
+
+        .table-danger th,
+        .table-danger td,
+        .table-danger thead th,
+        .table-danger tbody+tbody {
+          border-color: #f9b1b1;
+        }
+
+        .table-hover .table-danger:hover {
+          background-color: #fabdbd;
+        }
+
+        .table-hover .table-danger:hover>td,
+        .table-hover .table-danger:hover>th {
+          background-color: #fabdbd;
+        }
+
+        .table-light,
+        .table-light>th,
+        .table-light>td {
+          background-color: white;
+        }
+
+        .table-light th,
+        .table-light td,
+        .table-light thead th,
+        .table-light tbody+tbody {
+          border-color: white;
+        }
+
+        .table-hover .table-light:hover {
+          background-color: #f2f2f2;
+        }
+
+        .table-hover .table-light:hover>td,
+        .table-hover .table-light:hover>th {
+          background-color: #f2f2f2;
+        }
+
+        .table-dark,
+        .table-dark>th,
+        .table-dark>td {
+          background-color: #c6c6c6;
+        }
+
+        .table-dark th,
+        .table-dark td,
+        .table-dark thead th,
+        .table-dark tbody+tbody {
+          border-color: #969696;
+        }
+
+        .table-hover .table-dark:hover {
+          background-color: #b9b9b9;
+        }
+
+        .table-hover .table-dark:hover>td,
+        .table-hover .table-dark:hover>th {
+          background-color: #b9b9b9;
+        }
+
+        .table-active,
+        .table-active>th,
+        .table-active>td {
+          background-color: rgba(0, 0, 0, 0.075);
+        }
+
+        .table-hover .table-active:hover {
+          background-color: rgba(0, 0, 0, 0.075);
+        }
+
+        .table-hover .table-active:hover>td,
+        .table-hover .table-active:hover>th {
+          background-color: rgba(0, 0, 0, 0.075);
+        }
+
+        .table .thead-dark th {
+          color: #FFFFFF;
+          background-color: #212529;
+          border-color: #32383e;
+        }
+
+        .table .thead-light th {
+          color: #495057;
+          background-color: #e9ecef;
+          border-color: #dee2e6;
+        }
+
+        .table-dark {
+          color: #FFFFFF;
+          background-color: #212529;
+        }
+
+        .table-dark th,
+        .table-dark td,
+        .table-dark thead th {
+          border-color: #32383e;
+        }
+
+        .table-dark.table-bordered {
+          border: 0;
+        }
+
+        .table-dark.table-striped tbody tr:nth-of-type(odd) {
+          background-color: rgba(255, 255, 255, 0.05);
+        }
+
+        .table-dark.table-hover tbody tr:hover {
+          background-color: rgba(255, 255, 255, 0.075);
+        }
+
+        @media (max-width: 575.98px) {
+          .table-responsive-sm {
+            display: block;
+            width: 100%;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            -ms-overflow-style: -ms-autohiding-scrollbar;
+          }
+          .table-responsive-sm>.table-bordered {
+            border: 0;
+          }
+        }
+
+        @media (max-width: 767.98px) {
+          .table-responsive-md {
+            display: block;
+            width: 100%;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            -ms-overflow-style: -ms-autohiding-scrollbar;
+          }
+          .table-responsive-md>.table-bordered {
+            border: 0;
+          }
+        }
+
+        @media (max-width: 991.98px) {
+          .table-responsive-lg {
+            display: block;
+            width: 100%;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            -ms-overflow-style: -ms-autohiding-scrollbar;
+          }
+          .table-responsive-lg>.table-bordered {
+            border: 0;
+          }
+        }
+
+        @media (max-width: 1199.98px) {
+          .table-responsive-xl {
+            display: block;
+            width: 100%;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            -ms-overflow-style: -ms-autohiding-scrollbar;
+          }
+          .table-responsive-xl>.table-bordered {
+            border: 0;
+          }
+        }
+
+        .table-responsive {
+          display: block;
+          width: 100%;
+          overflow-x: auto;
+          -webkit-overflow-scrolling: touch;
+          -ms-overflow-style: -ms-autohiding-scrollbar;
+        }
+
+        .table-responsive>.table-bordered {
+          border: 0;
+        }
+
+        .form-control {
+          display: block;
+          width: 100%;
+          height: calc(2.25rem + 2px);
+          padding: 0.375rem 0.75rem;
+          font-size: 1rem;
+          font-weight: 400;
+          line-height: 1.5;
+          color: #495057;
+          background-color: #FFFFFF;
+          background-clip: padding-box;
+          border: 1px solid #ced4da;
+          border-radius: 0px;
+          transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .form-control {
+            transition: none;
+          }
+        }
+
+        .form-control::-ms-expand {
+          background-color: transparent;
+          border: 0;
+        }
+
+        .form-control:focus {
+          color: #495057;
+          background-color: #FFFFFF;
+          border-color: #7fbffe;
+          outline: 0;
+          box-shadow: 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .form-control::-webkit-input-placeholder {
+          color: #6c757d;
+          opacity: 1;
+        }
+
+        .form-control:-ms-input-placeholder {
+          color: #6c757d;
+          opacity: 1;
+        }
+
+        .form-control::-ms-input-placeholder {
+          color: #6c757d;
+          opacity: 1;
+        }
+
+        .form-control::placeholder {
+          color: #6c757d;
+          opacity: 1;
+        }
+
+        .form-control:disabled,
+        .form-control[readonly] {
+          background-color: #e9ecef;
+          opacity: 1;
+        }
+
+        select.form-control:focus::-ms-value {
+          color: #495057;
+          background-color: #FFFFFF;
+        }
+
+        .form-control-file,
+        .form-control-range {
+          display: block;
+          width: 100%;
+        }
+
+        .col-form-label {
+          padding-top: calc(0.375rem + 1px);
+          padding-bottom: calc(0.375rem + 1px);
+          margin-bottom: 0;
+          font-size: inherit;
+          line-height: 1.5;
+        }
+
+        .col-form-label-lg {
+          padding-top: calc(0.5rem + 1px);
+          padding-bottom: calc(0.5rem + 1px);
+          font-size: 1.25rem;
+          line-height: 1.5;
+        }
+
+        .col-form-label-sm {
+          padding-top: calc(0.25rem + 1px);
+          padding-bottom: calc(0.25rem + 1px);
+          font-size: 0.875rem;
+          line-height: 1.5;
+        }
+
+        .form-control-plaintext {
+          display: block;
+          width: 100%;
+          padding-top: 0.375rem;
+          padding-bottom: 0.375rem;
+          margin-bottom: 0;
+          line-height: 1.5;
+          color: #212529;
+          background-color: transparent;
+          border: solid transparent;
+          border-width: 1px 0;
+        }
+
+        .form-control-plaintext.form-control-sm,
+        .form-control-plaintext.form-control-lg {
+          padding-right: 0;
+          padding-left: 0;
+        }
+
+        .form-control-sm {
+          height: calc(1.8125rem + 2px);
+          padding: 0.25rem 0.5rem;
+          font-size: 0.875rem;
+          line-height: 1.5;
+          border-radius: 0.2rem;
+        }
+
+        .form-control-lg {
+          height: calc(2.875rem + 2px);
+          padding: 0.5rem 1rem;
+          font-size: 1.25rem;
+          line-height: 1.5;
+          border-radius: 0.3rem;
+        }
+
+        select.form-control[size],
+        select.form-control[multiple] {
+          height: auto;
+        }
+
+        textarea.form-control {
+          height: auto;
+        }
+
+        .form-group {
+          margin-bottom: 1rem;
+        }
+
+        .form-text {
+          display: block;
+          margin-top: 0.25rem;
+        }
+
+        .form-row {
+          display: flex;
+          flex-wrap: wrap;
+          margin-right: -5px;
+          margin-left: -5px;
+        }
+
+        .form-row>.col,
+        .form-row>[class*="col-"] {
+          padding-right: 5px;
+          padding-left: 5px;
+        }
+
+        .form-check {
+          position: relative;
+          display: block;
+          padding-left: 1.25rem;
+        }
+
+        .form-check-input {
+          position: absolute;
+          margin-top: 0.3rem;
+          margin-left: -1.25rem;
+        }
+
+        .form-check-input:disabled~.form-check-label {
+          color: #6c757d;
+        }
+
+        .form-check-label {
+          margin-bottom: 0;
+        }
+
+        .form-check-inline {
+          display: inline-flex;
+          align-items: center;
+          padding-left: 0;
+          margin-right: 0.75rem;
+        }
+
+        .form-check-inline .form-check-input {
+          position: static;
+          margin-top: 0;
+          margin-right: 0.3125rem;
+          margin-left: 0;
+        }
+
+        .valid-feedback {
+          display: none;
+          width: 100%;
+          margin-top: 0.25rem;
+          font-size: 80%;
+          color: #00BD55;
+        }
+
+        .valid-tooltip {
+          position: absolute;
+          top: 100%;
+          z-index: 5;
+          display: none;
+          max-width: 100%;
+          padding: 0.25rem 0.5rem;
+          margin-top: .1rem;
+          font-size: 0.875rem;
+          line-height: 1.5;
+          color: #FFFFFF;
+          background-color: rgba(0, 189, 85, 0.9);
+          border-radius: 0px;
+        }
+
+        .was-validated .form-control:valid,
+        .form-control.is-valid {
+          border-color: #00BD55;
+          padding-right: 2.25rem;
+          background-repeat: no-repeat;
+          background-position: center right calc(2.25rem / 4);
+          background-size: calc(2.25rem / 2) calc(2.25rem / 2);
+          background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2300BD55' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+        }
+
+        .was-validated .form-control:valid:focus,
+        .form-control.is-valid:focus {
+          border-color: #00BD55;
+          box-shadow: 0 0 0 0.2rem rgba(0, 189, 85, 0.25);
+        }
+
+        .was-validated .form-control:valid~.valid-feedback,
+        .was-validated .form-control:valid~.valid-tooltip,
+        .form-control.is-valid~.valid-feedback,
+        .form-control.is-valid~.valid-tooltip {
+          display: block;
+        }
+
+        .was-validated textarea.form-control:valid,
+        textarea.form-control.is-valid {
+          padding-right: 2.25rem;
+          background-position: top calc(2.25rem / 4) right calc(2.25rem / 4);
+        }
+
+        .was-validated .custom-select:valid,
+        .custom-select.is-valid {
+          border-color: #00BD55;
+          padding-right: 3.4375rem;
+          background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2300BD55' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") no-repeat center right 1.75rem/1.125rem 1.125rem;
+        }
+
+        .was-validated .custom-select:valid:focus,
+        .custom-select.is-valid:focus {
+          border-color: #00BD55;
+          box-shadow: 0 0 0 0.2rem rgba(0, 189, 85, 0.25);
+        }
+
+        .was-validated .custom-select:valid~.valid-feedback,
+        .was-validated .custom-select:valid~.valid-tooltip,
+        .custom-select.is-valid~.valid-feedback,
+        .custom-select.is-valid~.valid-tooltip {
+          display: block;
+        }
+
+        .was-validated .form-control-file:valid~.valid-feedback,
+        .was-validated .form-control-file:valid~.valid-tooltip,
+        .form-control-file.is-valid~.valid-feedback,
+        .form-control-file.is-valid~.valid-tooltip {
+          display: block;
+        }
+
+        .was-validated .form-check-input:valid~.form-check-label,
+        .form-check-input.is-valid~.form-check-label {
+          color: #00BD55;
+        }
+
+        .was-validated .form-check-input:valid~.valid-feedback,
+        .was-validated .form-check-input:valid~.valid-tooltip,
+        .form-check-input.is-valid~.valid-feedback,
+        .form-check-input.is-valid~.valid-tooltip {
+          display: block;
+        }
+
+        .was-validated .custom-control-input:valid~.custom-control-label,
+        .custom-control-input.is-valid~.custom-control-label {
+          color: #00BD55;
+        }
+
+        .was-validated .custom-control-input:valid~.custom-control-label::before,
+        .custom-control-input.is-valid~.custom-control-label::before {
+          border-color: #00BD55;
+        }
+
+        .was-validated .custom-control-input:valid~.valid-feedback,
+        .was-validated .custom-control-input:valid~.valid-tooltip,
+        .custom-control-input.is-valid~.valid-feedback,
+        .custom-control-input.is-valid~.valid-tooltip {
+          display: block;
+        }
+
+        .was-validated .custom-control-input:valid:checked~.custom-control-label::before,
+        .custom-control-input.is-valid:checked~.custom-control-label::before {
+          border-color: #00f06c;
+          background-color: #00f06c;
+        }
+
+        .was-validated .custom-control-input:valid:focus~.custom-control-label::before,
+        .custom-control-input.is-valid:focus~.custom-control-label::before {
+          box-shadow: 0 0 0 0.2rem rgba(0, 189, 85, 0.25);
+        }
+
+        .was-validated .custom-control-input:valid:focus:not(:checked)~.custom-control-label::before,
+        .custom-control-input.is-valid:focus:not(:checked)~.custom-control-label::before {
+          border-color: #00BD55;
+        }
+
+        .was-validated .custom-file-input:valid~.custom-file-label,
+        .custom-file-input.is-valid~.custom-file-label {
+          border-color: #00BD55;
+        }
+
+        .was-validated .custom-file-input:valid~.valid-feedback,
+        .was-validated .custom-file-input:valid~.valid-tooltip,
+        .custom-file-input.is-valid~.valid-feedback,
+        .custom-file-input.is-valid~.valid-tooltip {
+          display: block;
+        }
+
+        .was-validated .custom-file-input:valid:focus~.custom-file-label,
+        .custom-file-input.is-valid:focus~.custom-file-label {
+          border-color: #00BD55;
+          box-shadow: 0 0 0 0.2rem rgba(0, 189, 85, 0.25);
+        }
+
+        .invalid-feedback {
+          display: none;
+          width: 100%;
+          margin-top: 0.25rem;
+          font-size: 80%;
+          color: #F36969;
+        }
+
+        .invalid-tooltip {
+          position: absolute;
+          top: 100%;
+          z-index: 5;
+          display: none;
+          max-width: 100%;
+          padding: 0.25rem 0.5rem;
+          margin-top: .1rem;
+          font-size: 0.875rem;
+          line-height: 1.5;
+          color: #FFFFFF;
+          background-color: rgba(243, 105, 105, 0.9);
+          border-radius: 0px;
+        }
+
+        .was-validated .form-control:invalid,
+        .form-control.is-invalid {
+          border-color: #F36969;
+          padding-right: 2.25rem;
+          background-repeat: no-repeat;
+          background-position: center right calc(2.25rem / 4);
+          background-size: calc(2.25rem / 2) calc(2.25rem / 2);
+          background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23F36969' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E");
+        }
+
+        .was-validated .form-control:invalid:focus,
+        .form-control.is-invalid:focus {
+          border-color: #F36969;
+          box-shadow: 0 0 0 0.2rem rgba(243, 105, 105, 0.25);
+        }
+
+        .was-validated .form-control:invalid~.invalid-feedback,
+        .was-validated .form-control:invalid~.invalid-tooltip,
+        .form-control.is-invalid~.invalid-feedback,
+        .form-control.is-invalid~.invalid-tooltip {
+          display: block;
+        }
+
+        .was-validated textarea.form-control:invalid,
+        textarea.form-control.is-invalid {
+          padding-right: 2.25rem;
+          background-position: top calc(2.25rem / 4) right calc(2.25rem / 4);
+        }
+
+        .was-validated .custom-select:invalid,
+        .custom-select.is-invalid {
+          border-color: #F36969;
+          padding-right: 3.4375rem;
+          background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23F36969' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E") no-repeat center right 1.75rem/1.125rem 1.125rem;
+        }
+
+        .was-validated .custom-select:invalid:focus,
+        .custom-select.is-invalid:focus {
+          border-color: #F36969;
+          box-shadow: 0 0 0 0.2rem rgba(243, 105, 105, 0.25);
+        }
+
+        .was-validated .custom-select:invalid~.invalid-feedback,
+        .was-validated .custom-select:invalid~.invalid-tooltip,
+        .custom-select.is-invalid~.invalid-feedback,
+        .custom-select.is-invalid~.invalid-tooltip {
+          display: block;
+        }
+
+        .was-validated .form-control-file:invalid~.invalid-feedback,
+        .was-validated .form-control-file:invalid~.invalid-tooltip,
+        .form-control-file.is-invalid~.invalid-feedback,
+        .form-control-file.is-invalid~.invalid-tooltip {
+          display: block;
+        }
+
+        .was-validated .form-check-input:invalid~.form-check-label,
+        .form-check-input.is-invalid~.form-check-label {
+          color: #F36969;
+        }
+
+        .was-validated .form-check-input:invalid~.invalid-feedback,
+        .was-validated .form-check-input:invalid~.invalid-tooltip,
+        .form-check-input.is-invalid~.invalid-feedback,
+        .form-check-input.is-invalid~.invalid-tooltip {
+          display: block;
+        }
+
+        .was-validated .custom-control-input:invalid~.custom-control-label,
+        .custom-control-input.is-invalid~.custom-control-label {
+          color: #F36969;
+        }
+
+        .was-validated .custom-control-input:invalid~.custom-control-label::before,
+        .custom-control-input.is-invalid~.custom-control-label::before {
+          border-color: #F36969;
+        }
+
+        .was-validated .custom-control-input:invalid~.invalid-feedback,
+        .was-validated .custom-control-input:invalid~.invalid-tooltip,
+        .custom-control-input.is-invalid~.invalid-feedback,
+        .custom-control-input.is-invalid~.invalid-tooltip {
+          display: block;
+        }
+
+        .was-validated .custom-control-input:invalid:checked~.custom-control-label::before,
+        .custom-control-input.is-invalid:checked~.custom-control-label::before {
+          border-color: #f79898;
+          background-color: #f79898;
+        }
+
+        .was-validated .custom-control-input:invalid:focus~.custom-control-label::before,
+        .custom-control-input.is-invalid:focus~.custom-control-label::before {
+          box-shadow: 0 0 0 0.2rem rgba(243, 105, 105, 0.25);
+        }
+
+        .was-validated .custom-control-input:invalid:focus:not(:checked)~.custom-control-label::before,
+        .custom-control-input.is-invalid:focus:not(:checked)~.custom-control-label::before {
+          border-color: #F36969;
+        }
+
+        .was-validated .custom-file-input:invalid~.custom-file-label,
+        .custom-file-input.is-invalid~.custom-file-label {
+          border-color: #F36969;
+        }
+
+        .was-validated .custom-file-input:invalid~.invalid-feedback,
+        .was-validated .custom-file-input:invalid~.invalid-tooltip,
+        .custom-file-input.is-invalid~.invalid-feedback,
+        .custom-file-input.is-invalid~.invalid-tooltip {
+          display: block;
+        }
+
+        .was-validated .custom-file-input:invalid:focus~.custom-file-label,
+        .custom-file-input.is-invalid:focus~.custom-file-label {
+          border-color: #F36969;
+          box-shadow: 0 0 0 0.2rem rgba(243, 105, 105, 0.25);
+        }
+
+        .form-inline {
+          display: flex;
+          flex-flow: row wrap;
+          align-items: center;
+        }
+
+        .form-inline .form-check {
+          width: 100%;
+        }
+
+        @media (min-width: 576px) {
+          .form-inline label {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 0;
+          }
+          .form-inline .form-group {
+            display: flex;
+            flex: 0 0 auto;
+            flex-flow: row wrap;
+            align-items: center;
+            margin-bottom: 0;
+          }
+          .form-inline .form-control {
+            display: inline-block;
+            width: auto;
+            vertical-align: middle;
+          }
+          .form-inline .form-control-plaintext {
+            display: inline-block;
+          }
+          .form-inline .input-group,
+          .form-inline .custom-select {
+            width: auto;
+          }
+          .form-inline .form-check {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: auto;
+            padding-left: 0;
+          }
+          .form-inline .form-check-input {
+            position: relative;
+            margin-top: 0;
+            margin-right: 0.25rem;
+            margin-left: 0;
+          }
+          .form-inline .custom-control {
+            align-items: center;
+            justify-content: center;
+          }
+          .form-inline .custom-control-label {
+            margin-bottom: 0;
+          }
+        }
+
+        .btn {
+          display: inline-block;
+          font-weight: 400;
+          color: #212529;
+          text-align: center;
+          vertical-align: middle;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          -ms-user-select: none;
+          user-select: none;
+          background-color: transparent;
+          border: 1px solid transparent;
+          padding: 0.375rem 0.75rem;
+          font-size: 1rem;
+          line-height: 1.5;
+          border-radius: 0px;
+          transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .btn {
+            transition: none;
+          }
+        }
+
+        .btn:hover {
+          color: #212529;
+          text-decoration: none;
+        }
+
+        .btn:focus,
+        .btn.focus {
+          outline: 0;
+          box-shadow: 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .btn.disabled,
+        .btn:disabled {
+          opacity: 0.65;
+        }
+
+        .btn:not(:disabled):not(.disabled) {
+          cursor: pointer;
+        }
+
+        a.btn.disabled,
+        fieldset:disabled a.btn {
+          pointer-events: none;
+        }
+
+        .btn-primary {
+          color: #FFFFFF;
+          background-color: #017FFD;
+          border-color: #017FFD;
+        }
+
+        .btn-primary:hover {
+          color: #FFFFFF;
+          background-color: #016cd7;
+          border-color: #0166ca;
+        }
+
+        .btn-primary:focus,
+        .btn-primary.focus {
+          box-shadow: 0 0 0 0.2rem rgba(39, 146, 253, 0.5);
+        }
+
+        .btn-primary.disabled,
+        .btn-primary:disabled {
+          color: #FFFFFF;
+          background-color: #017FFD;
+          border-color: #017FFD;
+        }
+
+        .btn-primary:not(:disabled):not(.disabled):active,
+        .btn-primary:not(:disabled):not(.disabled).active,
+        .show>.btn-primary.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #0166ca;
+          border-color: #015fbe;
+        }
+
+        .btn-primary:not(:disabled):not(.disabled):active:focus,
+        .btn-primary:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-primary.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(39, 146, 253, 0.5);
+        }
+
+        .btn-secondary {
+          color: #FFFFFF;
+          background-color: #005EC4;
+          border-color: #005EC4;
+        }
+
+        .btn-secondary:hover {
+          color: #FFFFFF;
+          background-color: #004c9e;
+          border-color: #004691;
+        }
+
+        .btn-secondary:focus,
+        .btn-secondary.focus {
+          box-shadow: 0 0 0 0.2rem rgba(38, 118, 205, 0.5);
+        }
+
+        .btn-secondary.disabled,
+        .btn-secondary:disabled {
+          color: #FFFFFF;
+          background-color: #005EC4;
+          border-color: #005EC4;
+        }
+
+        .btn-secondary:not(:disabled):not(.disabled):active,
+        .btn-secondary:not(:disabled):not(.disabled).active,
+        .show>.btn-secondary.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #004691;
+          border-color: #003f84;
+        }
+
+        .btn-secondary:not(:disabled):not(.disabled):active:focus,
+        .btn-secondary:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-secondary.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(38, 118, 205, 0.5);
+        }
+
+        .btn-success {
+          color: #FFFFFF;
+          background-color: #00BD55;
+          border-color: #00BD55;
+        }
+
+        .btn-success:hover {
+          color: #FFFFFF;
+          background-color: #009744;
+          border-color: #008a3e;
+        }
+
+        .btn-success:focus,
+        .btn-success.focus {
+          box-shadow: 0 0 0 0.2rem rgba(38, 199, 111, 0.5);
+        }
+
+        .btn-success.disabled,
+        .btn-success:disabled {
+          color: #FFFFFF;
+          background-color: #00BD55;
+          border-color: #00BD55;
+        }
+
+        .btn-success:not(:disabled):not(.disabled):active,
+        .btn-success:not(:disabled):not(.disabled).active,
+        .show>.btn-success.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #008a3e;
+          border-color: #007d38;
+        }
+
+        .btn-success:not(:disabled):not(.disabled):active:focus,
+        .btn-success:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-success.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(38, 199, 111, 0.5);
+        }
+
+        .btn-info {
+          color: #FFFFFF;
+          background-color: #17a2b8;
+          border-color: #17a2b8;
+        }
+
+        .btn-info:hover {
+          color: #FFFFFF;
+          background-color: #138496;
+          border-color: #117a8b;
+        }
+
+        .btn-info:focus,
+        .btn-info.focus {
+          box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);
+        }
+
+        .btn-info.disabled,
+        .btn-info:disabled {
+          color: #FFFFFF;
+          background-color: #17a2b8;
+          border-color: #17a2b8;
+        }
+
+        .btn-info:not(:disabled):not(.disabled):active,
+        .btn-info:not(:disabled):not(.disabled).active,
+        .show>.btn-info.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #117a8b;
+          border-color: #10707f;
+        }
+
+        .btn-info:not(:disabled):not(.disabled):active:focus,
+        .btn-info:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-info.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);
+        }
+
+        .btn-warning {
+          color: #212529;
+          background-color: #ffc107;
+          border-color: #ffc107;
+        }
+
+        .btn-warning:hover {
+          color: #212529;
+          background-color: #e0a800;
+          border-color: #d39e00;
+        }
+
+        .btn-warning:focus,
+        .btn-warning.focus {
+          box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);
+        }
+
+        .btn-warning.disabled,
+        .btn-warning:disabled {
+          color: #212529;
+          background-color: #ffc107;
+          border-color: #ffc107;
+        }
+
+        .btn-warning:not(:disabled):not(.disabled):active,
+        .btn-warning:not(:disabled):not(.disabled).active,
+        .show>.btn-warning.dropdown-toggle {
+          color: #212529;
+          background-color: #d39e00;
+          border-color: #c69500;
+        }
+
+        .btn-warning:not(:disabled):not(.disabled):active:focus,
+        .btn-warning:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-warning.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);
+        }
+
+        .btn-danger {
+          color: #FFFFFF;
+          background-color: #F36969;
+          border-color: #F36969;
+        }
+
+        .btn-danger:hover {
+          color: #FFFFFF;
+          background-color: #f04646;
+          border-color: #ef3a3a;
+        }
+
+        .btn-danger:focus,
+        .btn-danger.focus {
+          box-shadow: 0 0 0 0.2rem rgba(245, 128, 128, 0.5);
+        }
+
+        .btn-danger.disabled,
+        .btn-danger:disabled {
+          color: #FFFFFF;
+          background-color: #F36969;
+          border-color: #F36969;
+        }
+
+        .btn-danger:not(:disabled):not(.disabled):active,
+        .btn-danger:not(:disabled):not(.disabled).active,
+        .show>.btn-danger.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #ef3a3a;
+          border-color: #ee2e2e;
+        }
+
+        .btn-danger:not(:disabled):not(.disabled):active:focus,
+        .btn-danger:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-danger.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(245, 128, 128, 0.5);
+        }
+
+        .btn-light {
+          color: #212529;
+          background-color: #FFFFFF;
+          border-color: #FFFFFF;
+        }
+
+        .btn-light:hover {
+          color: #212529;
+          background-color: #ececec;
+          border-color: #e6e6e6;
+        }
+
+        .btn-light:focus,
+        .btn-light.focus {
+          box-shadow: 0 0 0 0.2rem rgba(222, 222, 223, 0.5);
+        }
+
+        .btn-light.disabled,
+        .btn-light:disabled {
+          color: #212529;
+          background-color: #FFFFFF;
+          border-color: #FFFFFF;
+        }
+
+        .btn-light:not(:disabled):not(.disabled):active,
+        .btn-light:not(:disabled):not(.disabled).active,
+        .show>.btn-light.dropdown-toggle {
+          color: #212529;
+          background-color: #e6e6e6;
+          border-color: #dfdfdf;
+        }
+
+        .btn-light:not(:disabled):not(.disabled):active:focus,
+        .btn-light:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-light.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(222, 222, 223, 0.5);
+        }
+
+        .btn-dark {
+          color: #FFFFFF;
+          background-color: #353535;
+          border-color: #353535;
+        }
+
+        .btn-dark:hover {
+          color: #FFFFFF;
+          background-color: #222222;
+          border-color: #1c1c1c;
+        }
+
+        .btn-dark:focus,
+        .btn-dark.focus {
+          box-shadow: 0 0 0 0.2rem rgba(83, 83, 83, 0.5);
+        }
+
+        .btn-dark.disabled,
+        .btn-dark:disabled {
+          color: #FFFFFF;
+          background-color: #353535;
+          border-color: #353535;
+        }
+
+        .btn-dark:not(:disabled):not(.disabled):active,
+        .btn-dark:not(:disabled):not(.disabled).active,
+        .show>.btn-dark.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #1c1c1c;
+          border-color: #151515;
+        }
+
+        .btn-dark:not(:disabled):not(.disabled):active:focus,
+        .btn-dark:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-dark.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(83, 83, 83, 0.5);
+        }
+
+        .btn-outline-primary {
+          color: #017FFD;
+          border-color: #017FFD;
+        }
+
+        .btn-outline-primary:hover {
+          color: #FFFFFF;
+          background-color: #017FFD;
+          border-color: #017FFD;
+        }
+
+        .btn-outline-primary:focus,
+        .btn-outline-primary.focus {
+          box-shadow: 0 0 0 0.2rem rgba(1, 127, 253, 0.5);
+        }
+
+        .btn-outline-primary.disabled,
+        .btn-outline-primary:disabled {
+          color: #017FFD;
+          background-color: transparent;
+        }
+
+        .btn-outline-primary:not(:disabled):not(.disabled):active,
+        .btn-outline-primary:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-primary.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #017FFD;
+          border-color: #017FFD;
+        }
+
+        .btn-outline-primary:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-primary:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-primary.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(1, 127, 253, 0.5);
+        }
+
+        .btn-outline-secondary {
+          color: #005EC4;
+          border-color: #005EC4;
+        }
+
+        .btn-outline-secondary:hover {
+          color: #FFFFFF;
+          background-color: #005EC4;
+          border-color: #005EC4;
+        }
+
+        .btn-outline-secondary:focus,
+        .btn-outline-secondary.focus {
+          box-shadow: 0 0 0 0.2rem rgba(0, 94, 196, 0.5);
+        }
+
+        .btn-outline-secondary.disabled,
+        .btn-outline-secondary:disabled {
+          color: #005EC4;
+          background-color: transparent;
+        }
+
+        .btn-outline-secondary:not(:disabled):not(.disabled):active,
+        .btn-outline-secondary:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-secondary.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #005EC4;
+          border-color: #005EC4;
+        }
+
+        .btn-outline-secondary:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-secondary:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-secondary.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(0, 94, 196, 0.5);
+        }
+
+        .btn-outline-success {
+          color: #00BD55;
+          border-color: #00BD55;
+        }
+
+        .btn-outline-success:hover {
+          color: #FFFFFF;
+          background-color: #00BD55;
+          border-color: #00BD55;
+        }
+
+        .btn-outline-success:focus,
+        .btn-outline-success.focus {
+          box-shadow: 0 0 0 0.2rem rgba(0, 189, 85, 0.5);
+        }
+
+        .btn-outline-success.disabled,
+        .btn-outline-success:disabled {
+          color: #00BD55;
+          background-color: transparent;
+        }
+
+        .btn-outline-success:not(:disabled):not(.disabled):active,
+        .btn-outline-success:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-success.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #00BD55;
+          border-color: #00BD55;
+        }
+
+        .btn-outline-success:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-success:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-success.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(0, 189, 85, 0.5);
+        }
+
+        .btn-outline-info {
+          color: #17a2b8;
+          border-color: #17a2b8;
+        }
+
+        .btn-outline-info:hover {
+          color: #FFFFFF;
+          background-color: #17a2b8;
+          border-color: #17a2b8;
+        }
+
+        .btn-outline-info:focus,
+        .btn-outline-info.focus {
+          box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5);
+        }
+
+        .btn-outline-info.disabled,
+        .btn-outline-info:disabled {
+          color: #17a2b8;
+          background-color: transparent;
+        }
+
+        .btn-outline-info:not(:disabled):not(.disabled):active,
+        .btn-outline-info:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-info.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #17a2b8;
+          border-color: #17a2b8;
+        }
+
+        .btn-outline-info:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-info:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-info.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5);
+        }
+
+        .btn-outline-warning {
+          color: #ffc107;
+          border-color: #ffc107;
+        }
+
+        .btn-outline-warning:hover {
+          color: #212529;
+          background-color: #ffc107;
+          border-color: #ffc107;
+        }
+
+        .btn-outline-warning:focus,
+        .btn-outline-warning.focus {
+          box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5);
+        }
+
+        .btn-outline-warning.disabled,
+        .btn-outline-warning:disabled {
+          color: #ffc107;
+          background-color: transparent;
+        }
+
+        .btn-outline-warning:not(:disabled):not(.disabled):active,
+        .btn-outline-warning:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-warning.dropdown-toggle {
+          color: #212529;
+          background-color: #ffc107;
+          border-color: #ffc107;
+        }
+
+        .btn-outline-warning:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-warning:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-warning.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5);
+        }
+
+        .btn-outline-danger {
+          color: #F36969;
+          border-color: #F36969;
+        }
+
+        .btn-outline-danger:hover {
+          color: #FFFFFF;
+          background-color: #F36969;
+          border-color: #F36969;
+        }
+
+        .btn-outline-danger:focus,
+        .btn-outline-danger.focus {
+          box-shadow: 0 0 0 0.2rem rgba(243, 105, 105, 0.5);
+        }
+
+        .btn-outline-danger.disabled,
+        .btn-outline-danger:disabled {
+          color: #F36969;
+          background-color: transparent;
+        }
+
+        .btn-outline-danger:not(:disabled):not(.disabled):active,
+        .btn-outline-danger:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-danger.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #F36969;
+          border-color: #F36969;
+        }
+
+        .btn-outline-danger:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-danger:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-danger.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(243, 105, 105, 0.5);
+        }
+
+        .btn-outline-light {
+          color: #FFFFFF;
+          border-color: #FFFFFF;
+        }
+
+        .btn-outline-light:hover {
+          color: #212529;
+          background-color: #FFFFFF;
+          border-color: #FFFFFF;
+        }
+
+        .btn-outline-light:focus,
+        .btn-outline-light.focus {
+          box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.5);
+        }
+
+        .btn-outline-light.disabled,
+        .btn-outline-light:disabled {
+          color: #FFFFFF;
+          background-color: transparent;
+        }
+
+        .btn-outline-light:not(:disabled):not(.disabled):active,
+        .btn-outline-light:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-light.dropdown-toggle {
+          color: #212529;
+          background-color: #FFFFFF;
+          border-color: #FFFFFF;
+        }
+
+        .btn-outline-light:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-light:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-light.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.5);
+        }
+
+        .btn-outline-dark {
+          color: #353535;
+          border-color: #353535;
+        }
+
+        .btn-outline-dark:hover {
+          color: #FFFFFF;
+          background-color: #353535;
+          border-color: #353535;
+        }
+
+        .btn-outline-dark:focus,
+        .btn-outline-dark.focus {
+          box-shadow: 0 0 0 0.2rem rgba(53, 53, 53, 0.5);
+        }
+
+        .btn-outline-dark.disabled,
+        .btn-outline-dark:disabled {
+          color: #353535;
+          background-color: transparent;
+        }
+
+        .btn-outline-dark:not(:disabled):not(.disabled):active,
+        .btn-outline-dark:not(:disabled):not(.disabled).active,
+        .show>.btn-outline-dark.dropdown-toggle {
+          color: #FFFFFF;
+          background-color: #353535;
+          border-color: #353535;
+        }
+
+        .btn-outline-dark:not(:disabled):not(.disabled):active:focus,
+        .btn-outline-dark:not(:disabled):not(.disabled).active:focus,
+        .show>.btn-outline-dark.dropdown-toggle:focus {
+          box-shadow: 0 0 0 0.2rem rgba(53, 53, 53, 0.5);
+        }
+
+        .btn-link {
+          font-weight: 400;
+          color: #017FFD;
+        }
+
+        .btn-link:hover {
+          color: #0159b1;
+          text-decoration: underline;
+        }
+
+        .btn-link:focus,
+        .btn-link.focus {
+          text-decoration: underline;
+          box-shadow: none;
+        }
+
+        .btn-link:disabled,
+        .btn-link.disabled {
+          color: #6c757d;
+          pointer-events: none;
+        }
+
+        .btn-lg,
+        .btn-group-lg>.btn {
+          padding: 0.5rem 1rem;
+          font-size: 1.25rem;
+          line-height: 1.5;
+          border-radius: 0px;
+        }
+
+        .btn-sm,
+        .btn-group-sm>.btn {
+          padding: 0.25rem 0.5rem;
+          font-size: 0.875rem;
+          line-height: 1.5;
+          border-radius: 0px;
+        }
+
+        .btn-block {
+          display: block;
+          width: 100%;
+        }
+
+        .btn-block+.btn-block {
+          margin-top: 0.5rem;
+        }
+
+        input[type="submit"].btn-block,
+        input[type="reset"].btn-block,
+        input[type="button"].btn-block {
+          width: 100%;
+        }
+
+        .fade {
+          transition: opacity 0.15s linear;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .fade {
+            transition: none;
+          }
+        }
+
+        .fade:not(.show) {
+          opacity: 0;
+        }
+
+        .collapse:not(.show) {
+          display: none;
+        }
+
+        .collapsing {
+          position: relative;
+          height: 0;
+          overflow: hidden;
+          transition: height 0.35s ease;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .collapsing {
+            transition: none;
+          }
+        }
+
+        .dropup,
+        .dropright,
+        .dropdown,
+        .dropleft {
+          position: relative;
+        }
+
+        .dropdown-toggle::after {
+          display: inline-block;
+          margin-left: 0.255em;
+          vertical-align: 0.255em;
+          content: "";
+          border-top: 0.3em solid;
+          border-right: 0.3em solid transparent;
+          border-bottom: 0;
+          border-left: 0.3em solid transparent;
+        }
+
+        .dropdown-toggle:empty::after {
+          margin-left: 0;
+        }
+
+        .dropdown-menu {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          z-index: 1000;
+          display: none;
+          float: left;
+          min-width: 10rem;
+          padding: 0.5rem 0;
+          margin: 0.125rem 0 0;
+          font-size: 1rem;
+          color: #212529;
+          text-align: left;
+          list-style: none;
+          background-color: #FFFFFF;
+          background-clip: padding-box;
+          border: 1px solid rgba(0, 0, 0, 0.15);
+          border-radius: 0px;
+        }
+
+        .dropdown-menu-right {
+          right: 0;
+          left: auto;
+        }
+
+        @media (min-width: 576px) {
+          .dropdown-menu-sm-right {
+            right: 0;
+            left: auto;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .dropdown-menu-md-right {
+            right: 0;
+            left: auto;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .dropdown-menu-lg-right {
+            right: 0;
+            left: auto;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .dropdown-menu-xl-right {
+            right: 0;
+            left: auto;
+          }
+        }
+
+        .dropdown-menu-left {
+          right: auto;
+          left: 0;
+        }
+
+        @media (min-width: 576px) {
+          .dropdown-menu-sm-left {
+            right: auto;
+            left: 0;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .dropdown-menu-md-left {
+            right: auto;
+            left: 0;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .dropdown-menu-lg-left {
+            right: auto;
+            left: 0;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .dropdown-menu-xl-left {
+            right: auto;
+            left: 0;
+          }
+        }
+
+        .dropup .dropdown-menu {
+          top: auto;
+          bottom: 100%;
+          margin-top: 0;
+          margin-bottom: 0.125rem;
+        }
+
+        .dropup .dropdown-toggle::after {
+          display: inline-block;
+          margin-left: 0.255em;
+          vertical-align: 0.255em;
+          content: "";
+          border-top: 0;
+          border-right: 0.3em solid transparent;
+          border-bottom: 0.3em solid;
+          border-left: 0.3em solid transparent;
+        }
+
+        .dropup .dropdown-toggle:empty::after {
+          margin-left: 0;
+        }
+
+        .dropright .dropdown-menu {
+          top: 0;
+          right: auto;
+          left: 100%;
+          margin-top: 0;
+          margin-left: 0.125rem;
+        }
+
+        .dropright .dropdown-toggle::after {
+          display: inline-block;
+          margin-left: 0.255em;
+          vertical-align: 0.255em;
+          content: "";
+          border-top: 0.3em solid transparent;
+          border-right: 0;
+          border-bottom: 0.3em solid transparent;
+          border-left: 0.3em solid;
+        }
+
+        .dropright .dropdown-toggle:empty::after {
+          margin-left: 0;
+        }
+
+        .dropright .dropdown-toggle::after {
+          vertical-align: 0;
+        }
+
+        .dropleft .dropdown-menu {
+          top: 0;
+          right: 100%;
+          left: auto;
+          margin-top: 0;
+          margin-right: 0.125rem;
+        }
+
+        .dropleft .dropdown-toggle::after {
+          display: inline-block;
+          margin-left: 0.255em;
+          vertical-align: 0.255em;
+          content: "";
+        }
+
+        .dropleft .dropdown-toggle::after {
+          display: none;
+        }
+
+        .dropleft .dropdown-toggle::before {
+          display: inline-block;
+          margin-right: 0.255em;
+          vertical-align: 0.255em;
+          content: "";
+          border-top: 0.3em solid transparent;
+          border-right: 0.3em solid;
+          border-bottom: 0.3em solid transparent;
+        }
+
+        .dropleft .dropdown-toggle:empty::after {
+          margin-left: 0;
+        }
+
+        .dropleft .dropdown-toggle::before {
+          vertical-align: 0;
+        }
+
+        .dropdown-menu[x-placement^="top"],
+        .dropdown-menu[x-placement^="right"],
+        .dropdown-menu[x-placement^="bottom"],
+        .dropdown-menu[x-placement^="left"] {
+          right: auto;
+          bottom: auto;
+        }
+
+        .dropdown-divider {
+          height: 0;
+          margin: 0.5rem 0;
+          overflow: hidden;
+          border-top: 1px solid #e9ecef;
+        }
+
+        .dropdown-item {
+          display: block;
+          width: 100%;
+          padding: 0.25rem 1.5rem;
+          clear: both;
+          font-weight: 400;
+          color: #212529;
+          text-align: inherit;
+          white-space: nowrap;
+          background-color: transparent;
+          border: 0;
+        }
+
+        .dropdown-item:first-child {
+          border-top-left-radius: calc(0px - 1px);
+          border-top-right-radius: calc(0px - 1px);
+        }
+
+        .dropdown-item:last-child {
+          border-bottom-right-radius: calc(0px - 1px);
+          border-bottom-left-radius: calc(0px - 1px);
+        }
+
+        .dropdown-item:hover,
+        .dropdown-item:focus {
+          color: #16181b;
+          text-decoration: none;
+          background-color: #f8f9fa;
+        }
+
+        .dropdown-item.active,
+        .dropdown-item:active {
+          color: #FFFFFF;
+          text-decoration: none;
+          background-color: #017FFD;
+        }
+
+        .dropdown-item.disabled,
+        .dropdown-item:disabled {
+          color: #6c757d;
+          pointer-events: none;
+          background-color: transparent;
+        }
+
+        .dropdown-menu.show {
+          display: block;
+        }
+
+        .dropdown-header {
+          display: block;
+          padding: 0.5rem 1.5rem;
+          margin-bottom: 0;
+          font-size: 0.875rem;
+          color: #6c757d;
+          white-space: nowrap;
+        }
+
+        .dropdown-item-text {
+          display: block;
+          padding: 0.25rem 1.5rem;
+          color: #212529;
+        }
+
+        .btn-group,
+        .btn-group-vertical {
+          position: relative;
+          display: inline-flex;
+          vertical-align: middle;
+        }
+
+        .btn-group>.btn,
+        .btn-group-vertical>.btn {
+          position: relative;
+          flex: 1 1 auto;
+        }
+
+        .btn-group>.btn:hover,
+        .btn-group-vertical>.btn:hover {
+          z-index: 1;
+        }
+
+        .btn-group>.btn:focus,
+        .btn-group>.btn:active,
+        .btn-group>.btn.active,
+        .btn-group-vertical>.btn:focus,
+        .btn-group-vertical>.btn:active,
+        .btn-group-vertical>.btn.active {
+          z-index: 1;
+        }
+
+        .btn-toolbar {
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: flex-start;
+        }
+
+        .btn-toolbar .input-group {
+          width: auto;
+        }
+
+        .btn-group>.btn:not(:first-child),
+        .btn-group>.btn-group:not(:first-child) {
+          margin-left: -1px;
+        }
+
+        .btn-group>.btn:not(:last-child):not(.dropdown-toggle),
+        .btn-group>.btn-group:not(:last-child)>.btn {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+
+        .btn-group>.btn:not(:first-child),
+        .btn-group>.btn-group:not(:first-child)>.btn {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+
+        .dropdown-toggle-split {
+          padding-right: 0.5625rem;
+          padding-left: 0.5625rem;
+        }
+
+        .dropdown-toggle-split::after,
+        .dropup .dropdown-toggle-split::after,
+        .dropright .dropdown-toggle-split::after {
+          margin-left: 0;
+        }
+
+        .dropleft .dropdown-toggle-split::before {
+          margin-right: 0;
+        }
+
+        .btn-sm+.dropdown-toggle-split,
+        .btn-group-sm>.btn+.dropdown-toggle-split {
+          padding-right: 0.375rem;
+          padding-left: 0.375rem;
+        }
+
+        .btn-lg+.dropdown-toggle-split,
+        .btn-group-lg>.btn+.dropdown-toggle-split {
+          padding-right: 0.75rem;
+          padding-left: 0.75rem;
+        }
+
+        .btn-group-vertical {
+          flex-direction: column;
+          align-items: flex-start;
+          justify-content: center;
+        }
+
+        .btn-group-vertical>.btn,
+        .btn-group-vertical>.btn-group {
+          width: 100%;
+        }
+
+        .btn-group-vertical>.btn:not(:first-child),
+        .btn-group-vertical>.btn-group:not(:first-child) {
+          margin-top: -1px;
+        }
+
+        .btn-group-vertical>.btn:not(:last-child):not(.dropdown-toggle),
+        .btn-group-vertical>.btn-group:not(:last-child)>.btn {
+          border-bottom-right-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+
+        .btn-group-vertical>.btn:not(:first-child),
+        .btn-group-vertical>.btn-group:not(:first-child)>.btn {
+          border-top-left-radius: 0;
+          border-top-right-radius: 0;
+        }
+
+        .btn-group-toggle>.btn,
+        .btn-group-toggle>.btn-group>.btn {
+          margin-bottom: 0;
+        }
+
+        .btn-group-toggle>.btn input[type="radio"],
+        .btn-group-toggle>.btn input[type="checkbox"],
+        .btn-group-toggle>.btn-group>.btn input[type="radio"],
+        .btn-group-toggle>.btn-group>.btn input[type="checkbox"] {
+          position: absolute;
+          clip: rect(0, 0, 0, 0);
+          pointer-events: none;
+        }
+
+        .input-group {
+          position: relative;
+          display: flex;
+          flex-wrap: wrap;
+          align-items: stretch;
+          width: 100%;
+        }
+
+        .input-group>.form-control,
+        .input-group>.form-control-plaintext,
+        .input-group>.custom-select,
+        .input-group>.custom-file {
+          position: relative;
+          flex: 1 1 auto;
+          width: 1%;
+          margin-bottom: 0;
+        }
+
+        .input-group>.form-control+.form-control,
+        .input-group>.form-control+.custom-select,
+        .input-group>.form-control+.custom-file,
+        .input-group>.form-control-plaintext+.form-control,
+        .input-group>.form-control-plaintext+.custom-select,
+        .input-group>.form-control-plaintext+.custom-file,
+        .input-group>.custom-select+.form-control,
+        .input-group>.custom-select+.custom-select,
+        .input-group>.custom-select+.custom-file,
+        .input-group>.custom-file+.form-control,
+        .input-group>.custom-file+.custom-select,
+        .input-group>.custom-file+.custom-file {
+          margin-left: -1px;
+        }
+
+        .input-group>.form-control:focus,
+        .input-group>.custom-select:focus,
+        .input-group>.custom-file .custom-file-input:focus~.custom-file-label {
+          z-index: 3;
+        }
+
+        .input-group>.custom-file .custom-file-input:focus {
+          z-index: 4;
+        }
+
+        .input-group>.form-control:not(:last-child),
+        .input-group>.custom-select:not(:last-child) {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+
+        .input-group>.form-control:not(:first-child),
+        .input-group>.custom-select:not(:first-child) {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+
+        .input-group>.custom-file {
+          display: flex;
+          align-items: center;
+        }
+
+        .input-group>.custom-file:not(:last-child) .custom-file-label,
+        .input-group>.custom-file:not(:last-child) .custom-file-label::after {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+
+        .input-group>.custom-file:not(:first-child) .custom-file-label {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+
+        .input-group-prepend,
+        .input-group-append {
+          display: flex;
+        }
+
+        .input-group-prepend .btn,
+        .input-group-append .btn {
+          position: relative;
+          z-index: 2;
+        }
+
+        .input-group-prepend .btn:focus,
+        .input-group-append .btn:focus {
+          z-index: 3;
+        }
+
+        .input-group-prepend .btn+.btn,
+        .input-group-prepend .btn+.input-group-text,
+        .input-group-prepend .input-group-text+.input-group-text,
+        .input-group-prepend .input-group-text+.btn,
+        .input-group-append .btn+.btn,
+        .input-group-append .btn+.input-group-text,
+        .input-group-append .input-group-text+.input-group-text,
+        .input-group-append .input-group-text+.btn {
+          margin-left: -1px;
+        }
+
+        .input-group-prepend {
+          margin-right: -1px;
+        }
+
+        .input-group-append {
+          margin-left: -1px;
+        }
+
+        .input-group-text {
+          display: flex;
+          align-items: center;
+          padding: 0.375rem 0.75rem;
+          margin-bottom: 0;
+          font-size: 1rem;
+          font-weight: 400;
+          line-height: 1.5;
+          color: #495057;
+          text-align: center;
+          white-space: nowrap;
+          background-color: #e9ecef;
+          border: 1px solid #ced4da;
+          border-radius: 0px;
+        }
+
+        .input-group-text input[type="radio"],
+        .input-group-text input[type="checkbox"] {
+          margin-top: 0;
+        }
+
+        .input-group-lg>.form-control:not(textarea),
+        .input-group-lg>.custom-select {
+          height: calc(2.875rem + 2px);
+        }
+
+        .input-group-lg>.form-control,
+        .input-group-lg>.custom-select,
+        .input-group-lg>.input-group-prepend>.input-group-text,
+        .input-group-lg>.input-group-append>.input-group-text,
+        .input-group-lg>.input-group-prepend>.btn,
+        .input-group-lg>.input-group-append>.btn {
+          padding: 0.5rem 1rem;
+          font-size: 1.25rem;
+          line-height: 1.5;
+          border-radius: 0.3rem;
+        }
+
+        .input-group-sm>.form-control:not(textarea),
+        .input-group-sm>.custom-select {
+          height: calc(1.8125rem + 2px);
+        }
+
+        .input-group-sm>.form-control,
+        .input-group-sm>.custom-select,
+        .input-group-sm>.input-group-prepend>.input-group-text,
+        .input-group-sm>.input-group-append>.input-group-text,
+        .input-group-sm>.input-group-prepend>.btn,
+        .input-group-sm>.input-group-append>.btn {
+          padding: 0.25rem 0.5rem;
+          font-size: 0.875rem;
+          line-height: 1.5;
+          border-radius: 0.2rem;
+        }
+
+        .input-group-lg>.custom-select,
+        .input-group-sm>.custom-select {
+          padding-right: 1.75rem;
+        }
+
+        .input-group>.input-group-prepend>.btn,
+        .input-group>.input-group-prepend>.input-group-text,
+        .input-group>.input-group-append:not(:last-child)>.btn,
+        .input-group>.input-group-append:not(:last-child)>.input-group-text,
+        .input-group>.input-group-append:last-child>.btn:not(:last-child):not(.dropdown-toggle),
+        .input-group>.input-group-append:last-child>.input-group-text:not(:last-child) {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+
+        .input-group>.input-group-append>.btn,
+        .input-group>.input-group-append>.input-group-text,
+        .input-group>.input-group-prepend:not(:first-child)>.btn,
+        .input-group>.input-group-prepend:not(:first-child)>.input-group-text,
+        .input-group>.input-group-prepend:first-child>.btn:not(:first-child),
+        .input-group>.input-group-prepend:first-child>.input-group-text:not(:first-child) {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+
+        .custom-control {
+          position: relative;
+          display: block;
+          min-height: 1.5rem;
+          padding-left: 1.5rem;
+        }
+
+        .custom-control-inline {
+          display: inline-flex;
+          margin-right: 1rem;
+        }
+
+        .custom-control-input {
+          position: absolute;
+          z-index: -1;
+          opacity: 0;
+        }
+
+        .custom-control-input:checked~.custom-control-label::before {
+          color: #FFFFFF;
+          border-color: #017FFD;
+          background-color: #017FFD;
+        }
+
+        .custom-control-input:focus~.custom-control-label::before {
+          box-shadow: 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .custom-control-input:focus:not(:checked)~.custom-control-label::before {
+          border-color: #7fbffe;
+        }
+
+        .custom-control-input:not(:disabled):active~.custom-control-label::before {
+          color: #FFFFFF;
+          background-color: #b2d8ff;
+          border-color: #b2d8ff;
+        }
+
+        .custom-control-input:disabled~.custom-control-label {
+          color: #6c757d;
+        }
+
+        .custom-control-input:disabled~.custom-control-label::before {
+          background-color: #e9ecef;
+        }
+
+        .custom-control-label {
+          position: relative;
+          margin-bottom: 0;
+          vertical-align: top;
+        }
+
+        .custom-control-label::before {
+          position: absolute;
+          top: 0.25rem;
+          left: -1.5rem;
+          display: block;
+          width: 1rem;
+          height: 1rem;
+          pointer-events: none;
+          content: "";
+          background-color: #FFFFFF;
+          border: #adb5bd solid 1px;
+        }
+
+        .custom-control-label::after {
+          position: absolute;
+          top: 0.25rem;
+          left: -1.5rem;
+          display: block;
+          width: 1rem;
+          height: 1rem;
+          content: "";
+          background-repeat: no-repeat;
+          background-position: center center;
+          background-size: 50% 50%;
+        }
+
+        .custom-checkbox .custom-control-label::before {
+          border-radius: 0px;
+        }
+
+        .custom-checkbox .custom-control-input:checked~.custom-control-label::after {
+          background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23FFFFFF' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e");
+        }
+
+        .custom-checkbox .custom-control-input:indeterminate~.custom-control-label::before {
+          border-color: #017FFD;
+          background-color: #017FFD;
+        }
+
+        .custom-checkbox .custom-control-input:indeterminate~.custom-control-label::after {
+          background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='%23FFFFFF' d='M0 2h4'/%3e%3c/svg%3e");
+        }
+
+        .custom-checkbox .custom-control-input:disabled:checked~.custom-control-label::before {
+          background-color: rgba(1, 127, 253, 0.5);
+        }
+
+        .custom-checkbox .custom-control-input:disabled:indeterminate~.custom-control-label::before {
+          background-color: rgba(1, 127, 253, 0.5);
+        }
+
+        .custom-radio .custom-control-label::before {
+          border-radius: 50%;
+        }
+
+        .custom-radio .custom-control-input:checked~.custom-control-label::after {
+          background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23FFFFFF'/%3e%3c/svg%3e");
+        }
+
+        .custom-radio .custom-control-input:disabled:checked~.custom-control-label::before {
+          background-color: rgba(1, 127, 253, 0.5);
+        }
+
+        .custom-switch {
+          padding-left: 2.25rem;
+        }
+
+        .custom-switch .custom-control-label::before {
+          left: -2.25rem;
+          width: 1.75rem;
+          pointer-events: all;
+          border-radius: 0.5rem;
+        }
+
+        .custom-switch .custom-control-label::after {
+          top: calc(0.25rem + 2px);
+          left: calc(-2.25rem + 2px);
+          width: calc(1rem - 4px);
+          height: calc(1rem - 4px);
+          background-color: #adb5bd;
+          border-radius: 0.5rem;
+          transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out;
+          transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+          transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .custom-switch .custom-control-label::after {
+            transition: none;
+          }
+        }
+
+        .custom-switch .custom-control-input:checked~.custom-control-label::after {
+          background-color: #FFFFFF;
+          -webkit-transform: translateX(0.75rem);
+          transform: translateX(0.75rem);
+        }
+
+        .custom-switch .custom-control-input:disabled:checked~.custom-control-label::before {
+          background-color: rgba(1, 127, 253, 0.5);
+        }
+
+        .custom-select {
+          display: inline-block;
+          width: 100%;
+          height: calc(2.25rem + 2px);
+          padding: 0.375rem 1.75rem 0.375rem 0.75rem;
+          font-weight: 400;
+          line-height: 1.5;
+          color: #495057;
+          vertical-align: middle;
+          background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px;
+          background-color: #FFFFFF;
+          border: 1px solid #ced4da;
+          border-radius: 0px;
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          appearance: none;
+        }
+
+        .custom-select:focus {
+          border-color: #7fbffe;
+          outline: 0;
+          box-shadow: 0 0 0 0.2rem rgba(127, 191, 254, 0.5);
+        }
+
+        .custom-select:focus::-ms-value {
+          color: #495057;
+          background-color: #FFFFFF;
+        }
+
+        .custom-select[multiple],
+        .custom-select[size]:not([size="1"]) {
+          height: auto;
+          padding-right: 0.75rem;
+          background-image: none;
+        }
+
+        .custom-select:disabled {
+          color: #6c757d;
+          background-color: #e9ecef;
+        }
+
+        .custom-select::-ms-expand {
+          opacity: 0;
+        }
+
+        .custom-select-sm {
+          height: calc(1.8125rem + 2px);
+          padding-top: 0.25rem;
+          padding-bottom: 0.25rem;
+          padding-left: 0.5rem;
+          font-size: 0.875rem;
+        }
+
+        .custom-select-lg {
+          height: calc(2.875rem + 2px);
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
+          padding-left: 1rem;
+          font-size: 1.25rem;
+        }
+
+        .custom-file {
+          position: relative;
+          display: inline-block;
+          width: 100%;
+          height: calc(2.25rem + 2px);
+          margin-bottom: 0;
+        }
+
+        .custom-file-input {
+          position: relative;
+          z-index: 2;
+          width: 100%;
+          height: calc(2.25rem + 2px);
+          margin: 0;
+          opacity: 0;
+        }
+
+        .custom-file-input:focus~.custom-file-label {
+          border-color: #7fbffe;
+          box-shadow: 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .custom-file-input:disabled~.custom-file-label {
+          background-color: #e9ecef;
+        }
+
+        .custom-file-input:lang(en)~.custom-file-label::after {
+          content: "Browse";
+        }
+
+        .custom-file-input~.custom-file-label[data-browse]::after {
+          content: attr(data-browse);
+        }
+
+        .custom-file-label {
+          position: absolute;
+          top: 0;
+          right: 0;
+          left: 0;
+          z-index: 1;
+          height: calc(2.25rem + 2px);
+          padding: 0.375rem 0.75rem;
+          font-weight: 400;
+          line-height: 1.5;
+          color: #495057;
+          background-color: #FFFFFF;
+          border: 1px solid #ced4da;
+          border-radius: 0px;
+        }
+
+        .custom-file-label::after {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          z-index: 3;
+          display: block;
+          height: 2.25rem;
+          padding: 0.375rem 0.75rem;
+          line-height: 1.5;
+          color: #495057;
+          content: "Browse";
+          background-color: #e9ecef;
+          border-left: inherit;
+          border-radius: 0 0px 0px 0;
+        }
+
+        .custom-range {
+          width: 100%;
+          height: calc(1rem + 0.4rem);
+          padding: 0;
+          background-color: transparent;
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          appearance: none;
+        }
+
+        .custom-range:focus {
+          outline: none;
+        }
+
+        .custom-range:focus::-webkit-slider-thumb {
+          box-shadow: 0 0 0 1px #fafafa, 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .custom-range:focus::-moz-range-thumb {
+          box-shadow: 0 0 0 1px #fafafa, 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .custom-range:focus::-ms-thumb {
+          box-shadow: 0 0 0 1px #fafafa, 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .custom-range::-moz-focus-outer {
+          border: 0;
+        }
+
+        .custom-range::-webkit-slider-thumb {
+          width: 1rem;
+          height: 1rem;
+          margin-top: -0.25rem;
+          background-color: #017FFD;
+          border: 0;
+          border-radius: 1rem;
+          transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+          -webkit-appearance: none;
+          appearance: none;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .custom-range::-webkit-slider-thumb {
+            transition: none;
+          }
+        }
+
+        .custom-range::-webkit-slider-thumb:active {
+          background-color: #b2d8ff;
+        }
+
+        .custom-range::-webkit-slider-runnable-track {
+          width: 100%;
+          height: 0.5rem;
+          color: transparent;
+          cursor: pointer;
+          background-color: #dee2e6;
+          border-color: transparent;
+          border-radius: 1rem;
+        }
+
+        .custom-range::-moz-range-thumb {
+          width: 1rem;
+          height: 1rem;
+          background-color: #017FFD;
+          border: 0;
+          border-radius: 1rem;
+          transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+          -moz-appearance: none;
+          appearance: none;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .custom-range::-moz-range-thumb {
+            transition: none;
+          }
+        }
+
+        .custom-range::-moz-range-thumb:active {
+          background-color: #b2d8ff;
+        }
+
+        .custom-range::-moz-range-track {
+          width: 100%;
+          height: 0.5rem;
+          color: transparent;
+          cursor: pointer;
+          background-color: #dee2e6;
+          border-color: transparent;
+          border-radius: 1rem;
+        }
+
+        .custom-range::-ms-thumb {
+          width: 1rem;
+          height: 1rem;
+          margin-top: 0;
+          margin-right: 0.2rem;
+          margin-left: 0.2rem;
+          background-color: #017FFD;
+          border: 0;
+          border-radius: 1rem;
+          transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+          appearance: none;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .custom-range::-ms-thumb {
+            transition: none;
+          }
+        }
+
+        .custom-range::-ms-thumb:active {
+          background-color: #b2d8ff;
+        }
+
+        .custom-range::-ms-track {
+          width: 100%;
+          height: 0.5rem;
+          color: transparent;
+          cursor: pointer;
+          background-color: transparent;
+          border-color: transparent;
+          border-width: 0.5rem;
+        }
+
+        .custom-range::-ms-fill-lower {
+          background-color: #dee2e6;
+          border-radius: 1rem;
+        }
+
+        .custom-range::-ms-fill-upper {
+          margin-right: 15px;
+          background-color: #dee2e6;
+          border-radius: 1rem;
+        }
+
+        .custom-range:disabled::-webkit-slider-thumb {
+          background-color: #adb5bd;
+        }
+
+        .custom-range:disabled::-webkit-slider-runnable-track {
+          cursor: default;
+        }
+
+        .custom-range:disabled::-moz-range-thumb {
+          background-color: #adb5bd;
+        }
+
+        .custom-range:disabled::-moz-range-track {
+          cursor: default;
+        }
+
+        .custom-range:disabled::-ms-thumb {
+          background-color: #adb5bd;
+        }
+
+        .custom-control-label::before,
+        .custom-file-label,
+        .custom-select {
+          transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .custom-control-label::before,
+          .custom-file-label,
+          .custom-select {
+            transition: none;
+          }
+        }
+
+        .nav {
+          display: flex;
+          flex-wrap: wrap;
+          padding-left: 0;
+          margin-bottom: 0;
+          list-style: none;
+        }
+
+        .nav-link {
+          display: block;
+          padding: 0.5rem 1rem;
+        }
+
+        .nav-link:hover,
+        .nav-link:focus {
+          text-decoration: none;
+        }
+
+        .nav-link.disabled {
+          color: #6c757d;
+          pointer-events: none;
+          cursor: default;
+        }
+
+        .nav-tabs {
+          border-bottom: 1px solid #dee2e6;
+        }
+
+        .nav-tabs .nav-item {
+          margin-bottom: -1px;
+        }
+
+        .nav-tabs .nav-link {
+          border: 1px solid transparent;
+          border-top-left-radius: 0px;
+          border-top-right-radius: 0px;
+        }
+
+        .nav-tabs .nav-link:hover,
+        .nav-tabs .nav-link:focus {
+          border-color: #e9ecef #e9ecef #dee2e6;
+        }
+
+        .nav-tabs .nav-link.disabled {
+          color: #6c757d;
+          background-color: transparent;
+          border-color: transparent;
+        }
+
+        .nav-tabs .nav-link.active,
+        .nav-tabs .nav-item.show .nav-link {
+          color: #495057;
+          background-color: #fafafa;
+          border-color: #dee2e6 #dee2e6 #fafafa;
+        }
+
+        .nav-tabs .dropdown-menu {
+          margin-top: -1px;
+          border-top-left-radius: 0;
+          border-top-right-radius: 0;
+        }
+
+        .nav-pills .nav-link {
+          border-radius: 0px;
+        }
+
+        .nav-pills .nav-link.active,
+        .nav-pills .show>.nav-link {
+          color: #FFFFFF;
+          background-color: #017FFD;
+        }
+
+        .nav-fill .nav-item {
+          flex: 1 1 auto;
+          text-align: center;
+        }
+
+        .nav-justified .nav-item {
+          flex-basis: 0;
+          flex-grow: 1;
+          text-align: center;
+        }
+
+        .tab-content>.tab-pane {
+          display: none;
+        }
+
+        .tab-content>.active {
+          display: block;
+        }
+
+        .navbar {
+          position: relative;
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          justify-content: space-between;
+          padding: 0.5rem 1rem;
+        }
+
+        .navbar>.container,
+        .navbar>.container-fluid {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          justify-content: space-between;
+        }
+
+        .navbar-brand {
+          display: inline-block;
+          padding-top: 0.3125rem;
+          padding-bottom: 0.3125rem;
+          margin-right: 1rem;
+          font-size: 1.25rem;
+          line-height: inherit;
+          white-space: nowrap;
+        }
+
+        .navbar-brand:hover,
+        .navbar-brand:focus {
+          text-decoration: none;
+        }
+
+        .navbar-nav {
+          display: flex;
+          flex-direction: column;
+          padding-left: 0;
+          margin-bottom: 0;
+          list-style: none;
+        }
+
+        .navbar-nav .nav-link {
+          padding-right: 0;
+          padding-left: 0;
+        }
+
+        .navbar-nav .dropdown-menu {
+          position: static;
+          float: none;
+        }
+
+        .navbar-text {
+          display: inline-block;
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
+        }
+
+        .navbar-collapse {
+          flex-basis: 100%;
+          flex-grow: 1;
+          align-items: center;
+        }
+
+        .navbar-toggler {
+          padding: 0.25rem 0.75rem;
+          font-size: 1.25rem;
+          line-height: 1;
+          background-color: transparent;
+          border: 1px solid transparent;
+          border-radius: 0px;
+        }
+
+        .navbar-toggler:hover,
+        .navbar-toggler:focus {
+          text-decoration: none;
+        }
+
+        .navbar-toggler:not(:disabled):not(.disabled) {
+          cursor: pointer;
+        }
+
+        .navbar-toggler-icon {
+          display: inline-block;
+          width: 1.5em;
+          height: 1.5em;
+          vertical-align: middle;
+          content: "";
+          background: no-repeat center center;
+          background-size: 100% 100%;
+        }
+
+        @media (max-width: 575.98px) {
+          .navbar-expand-sm>.container,
+          .navbar-expand-sm>.container-fluid {
+            padding-right: 0;
+            padding-left: 0;
+          }
+        }
+
+        @media (min-width: 576px) {
+          .navbar-expand-sm {
+            flex-flow: row nowrap;
+            justify-content: flex-start;
+          }
+          .navbar-expand-sm .navbar-nav {
+            flex-direction: row;
+          }
+          .navbar-expand-sm .navbar-nav .dropdown-menu {
+            position: absolute;
+          }
+          .navbar-expand-sm .navbar-nav .nav-link {
+            padding-right: 0.5rem;
+            padding-left: 0.5rem;
+          }
+          .navbar-expand-sm>.container,
+          .navbar-expand-sm>.container-fluid {
+            flex-wrap: nowrap;
+          }
+          .navbar-expand-sm .navbar-collapse {
+            display: flex !important;
+            flex-basis: auto;
+          }
+          .navbar-expand-sm .navbar-toggler {
+            display: none;
+          }
+        }
+
+        @media (max-width: 767.98px) {
+          .navbar-expand-md>.container,
+          .navbar-expand-md>.container-fluid {
+            padding-right: 0;
+            padding-left: 0;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .navbar-expand-md {
+            flex-flow: row nowrap;
+            justify-content: flex-start;
+          }
+          .navbar-expand-md .navbar-nav {
+            flex-direction: row;
+          }
+          .navbar-expand-md .navbar-nav .dropdown-menu {
+            position: absolute;
+          }
+          .navbar-expand-md .navbar-nav .nav-link {
+            padding-right: 0.5rem;
+            padding-left: 0.5rem;
+          }
+          .navbar-expand-md>.container,
+          .navbar-expand-md>.container-fluid {
+            flex-wrap: nowrap;
+          }
+          .navbar-expand-md .navbar-collapse {
+            display: flex !important;
+            flex-basis: auto;
+          }
+          .navbar-expand-md .navbar-toggler {
+            display: none;
+          }
+        }
+
+        @media (max-width: 991.98px) {
+          .navbar-expand-lg>.container,
+          .navbar-expand-lg>.container-fluid {
+            padding-right: 0;
+            padding-left: 0;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .navbar-expand-lg {
+            flex-flow: row nowrap;
+            justify-content: flex-start;
+          }
+          .navbar-expand-lg .navbar-nav {
+            flex-direction: row;
+          }
+          .navbar-expand-lg .navbar-nav .dropdown-menu {
+            position: absolute;
+          }
+          .navbar-expand-lg .navbar-nav .nav-link {
+            padding-right: 0.5rem;
+            padding-left: 0.5rem;
+          }
+          .navbar-expand-lg>.container,
+          .navbar-expand-lg>.container-fluid {
+            flex-wrap: nowrap;
+          }
+          .navbar-expand-lg .navbar-collapse {
+            display: flex !important;
+            flex-basis: auto;
+          }
+          .navbar-expand-lg .navbar-toggler {
+            display: none;
+          }
+        }
+
+        @media (max-width: 1199.98px) {
+          .navbar-expand-xl>.container,
+          .navbar-expand-xl>.container-fluid {
+            padding-right: 0;
+            padding-left: 0;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .navbar-expand-xl {
+            flex-flow: row nowrap;
+            justify-content: flex-start;
+          }
+          .navbar-expand-xl .navbar-nav {
+            flex-direction: row;
+          }
+          .navbar-expand-xl .navbar-nav .dropdown-menu {
+            position: absolute;
+          }
+          .navbar-expand-xl .navbar-nav .nav-link {
+            padding-right: 0.5rem;
+            padding-left: 0.5rem;
+          }
+          .navbar-expand-xl>.container,
+          .navbar-expand-xl>.container-fluid {
+            flex-wrap: nowrap;
+          }
+          .navbar-expand-xl .navbar-collapse {
+            display: flex !important;
+            flex-basis: auto;
+          }
+          .navbar-expand-xl .navbar-toggler {
+            display: none;
+          }
+        }
+
+        .navbar-expand {
+          flex-flow: row nowrap;
+          justify-content: flex-start;
+        }
+
+        .navbar-expand>.container,
+        .navbar-expand>.container-fluid {
+          padding-right: 0;
+          padding-left: 0;
+        }
+
+        .navbar-expand .navbar-nav {
+          flex-direction: row;
+        }
+
+        .navbar-expand .navbar-nav .dropdown-menu {
+          position: absolute;
+        }
+
+        .navbar-expand .navbar-nav .nav-link {
+          padding-right: 0.5rem;
+          padding-left: 0.5rem;
+        }
+
+        .navbar-expand>.container,
+        .navbar-expand>.container-fluid {
+          flex-wrap: nowrap;
+        }
+
+        .navbar-expand .navbar-collapse {
+          display: flex !important;
+          flex-basis: auto;
+        }
+
+        .navbar-expand .navbar-toggler {
+          display: none;
+        }
+
+        .navbar-light .navbar-brand {
+          color: #000;
+        }
+
+        .navbar-light .navbar-brand:hover,
+        .navbar-light .navbar-brand:focus {
+          color: #000;
+        }
+
+        .navbar-light .navbar-nav .nav-link {
+          color: #017FFD;
+        }
+
+        .navbar-light .navbar-nav .nav-link:hover,
+        .navbar-light .navbar-nav .nav-link:focus {
+          color: rgba(0, 0, 0, 0.9);
+        }
+
+        .navbar-light .navbar-nav .nav-link.disabled {
+          color: rgba(0, 0, 0, 0.3);
+        }
+
+        .navbar-light .navbar-nav .show>.nav-link,
+        .navbar-light .navbar-nav .active>.nav-link,
+        .navbar-light .navbar-nav .nav-link.show,
+        .navbar-light .navbar-nav .nav-link.active {
+          color: #000;
+        }
+
+        .navbar-light .navbar-toggler {
+          color: #017FFD;
+          border-color: rgba(0, 0, 0, 0.1);
+        }
+
+        .navbar-light .navbar-toggler-icon {
+          background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='%23017FFD' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+        }
+
+        .navbar-light .navbar-text {
+          color: #017FFD;
+        }
+
+        .navbar-light .navbar-text a {
+          color: #000;
+        }
+
+        .navbar-light .navbar-text a:hover,
+        .navbar-light .navbar-text a:focus {
+          color: #000;
+        }
+
+        .navbar-dark .navbar-brand {
+          color: #FFFFFF;
+        }
+
+        .navbar-dark .navbar-brand:hover,
+        .navbar-dark .navbar-brand:focus {
+          color: #FFFFFF;
+        }
+
+        .navbar-dark .navbar-nav .nav-link {
+          color: rgba(255, 255, 255, 0.5);
+        }
+
+        .navbar-dark .navbar-nav .nav-link:hover,
+        .navbar-dark .navbar-nav .nav-link:focus {
+          color: rgba(255, 255, 255, 0.75);
+        }
+
+        .navbar-dark .navbar-nav .nav-link.disabled {
+          color: rgba(255, 255, 255, 0.25);
+        }
+
+        .navbar-dark .navbar-nav .show>.nav-link,
+        .navbar-dark .navbar-nav .active>.nav-link,
+        .navbar-dark .navbar-nav .nav-link.show,
+        .navbar-dark .navbar-nav .nav-link.active {
+          color: #FFFFFF;
+        }
+
+        .navbar-dark .navbar-toggler {
+          color: rgba(255, 255, 255, 0.5);
+          border-color: rgba(255, 255, 255, 0.1);
+        }
+
+        .navbar-dark .navbar-toggler-icon {
+          background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+        }
+
+        .navbar-dark .navbar-text {
+          color: rgba(255, 255, 255, 0.5);
+        }
+
+        .navbar-dark .navbar-text a {
+          color: #FFFFFF;
+        }
+
+        .navbar-dark .navbar-text a:hover,
+        .navbar-dark .navbar-text a:focus {
+          color: #FFFFFF;
+        }
+
+        .card {
+          position: relative;
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
+          word-wrap: break-word;
+          background-color: #FFFFFF;
+          background-clip: border-box;
+          border: 1px solid rgba(0, 0, 0, 0.125);
+          border-radius: 0px;
+        }
+
+        .card>hr {
+          margin-right: 0;
+          margin-left: 0;
+        }
+
+        .card>.list-group:first-child .list-group-item:first-child {
+          border-top-left-radius: 0px;
+          border-top-right-radius: 0px;
+        }
+
+        .card>.list-group:last-child .list-group-item:last-child {
+          border-bottom-right-radius: 0px;
+          border-bottom-left-radius: 0px;
+        }
+
+        .card-body {
+          flex: 1 1 auto;
+          padding: 1.25rem;
+        }
+
+        .card-title {
+          margin-bottom: 0.75rem;
+        }
+
+        .card-subtitle {
+          margin-top: -0.375rem;
+          margin-bottom: 0;
+        }
+
+        .card-text:last-child {
+          margin-bottom: 0;
+        }
+
+        .card-link:hover {
+          text-decoration: none;
+        }
+
+        .card-link+.card-link {
+          margin-left: 1.25rem;
+        }
+
+        .card-header {
+          padding: 0.75rem 1.25rem;
+          margin-bottom: 0;
+          color: inherit;
+          background-color: rgba(0, 0, 0, 0.03);
+          border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+        }
+
+        .card-header:first-child {
+          border-radius: calc(0px - 1px) calc(0px - 1px) 0 0;
+        }
+
+        .card-header+.list-group .list-group-item:first-child {
+          border-top: 0;
+        }
+
+        .card-footer {
+          padding: 0.75rem 1.25rem;
+          background-color: rgba(0, 0, 0, 0.03);
+          border-top: 1px solid rgba(0, 0, 0, 0.125);
+        }
+
+        .card-footer:last-child {
+          border-radius: 0 0 calc(0px - 1px) calc(0px - 1px);
+        }
+
+        .card-header-tabs {
+          margin-right: -0.625rem;
+          margin-bottom: -0.75rem;
+          margin-left: -0.625rem;
+          border-bottom: 0;
+        }
+
+        .card-header-pills {
+          margin-right: -0.625rem;
+          margin-left: -0.625rem;
+        }
+
+        .card-img-overlay {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          padding: 1.25rem;
+        }
+
+        .card-img {
+          width: 100%;
+          border-radius: calc(0px - 1px);
+        }
+
+        .card-img-top {
+          width: 100%;
+          border-top-left-radius: calc(0px - 1px);
+          border-top-right-radius: calc(0px - 1px);
+        }
+
+        .card-img-bottom {
+          width: 100%;
+          border-bottom-right-radius: calc(0px - 1px);
+          border-bottom-left-radius: calc(0px - 1px);
+        }
+
+        .card-deck {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .card-deck .card {
+          margin-bottom: 15px;
+        }
+
+        @media (min-width: 576px) {
+          .card-deck {
+            flex-flow: row wrap;
+            margin-right: -15px;
+            margin-left: -15px;
+          }
+          .card-deck .card {
+            display: flex;
+            flex: 1 0 0%;
+            flex-direction: column;
+            margin-right: 15px;
+            margin-bottom: 0;
+            margin-left: 15px;
+          }
+        }
+
+        .card-group {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .card-group>.card {
+          margin-bottom: 15px;
+        }
+
+        @media (min-width: 576px) {
+          .card-group {
+            flex-flow: row wrap;
+          }
+          .card-group>.card {
+            flex: 1 0 0%;
+            margin-bottom: 0;
+          }
+          .card-group>.card+.card {
+            margin-left: 0;
+            border-left: 0;
+          }
+          .card-group>.card:first-child {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+          }
+          .card-group>.card:first-child .card-img-top,
+          .card-group>.card:first-child .card-header {
+            border-top-right-radius: 0;
+          }
+          .card-group>.card:first-child .card-img-bottom,
+          .card-group>.card:first-child .card-footer {
+            border-bottom-right-radius: 0;
+          }
+          .card-group>.card:last-child {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+          }
+          .card-group>.card:last-child .card-img-top,
+          .card-group>.card:last-child .card-header {
+            border-top-left-radius: 0;
+          }
+          .card-group>.card:last-child .card-img-bottom,
+          .card-group>.card:last-child .card-footer {
+            border-bottom-left-radius: 0;
+          }
+          .card-group>.card:only-child {
+            border-radius: 0px;
+          }
+          .card-group>.card:only-child .card-img-top,
+          .card-group>.card:only-child .card-header {
+            border-top-left-radius: 0px;
+            border-top-right-radius: 0px;
+          }
+          .card-group>.card:only-child .card-img-bottom,
+          .card-group>.card:only-child .card-footer {
+            border-bottom-right-radius: 0px;
+            border-bottom-left-radius: 0px;
+          }
+          .card-group>.card:not(:first-child):not(:last-child):not(:only-child) {
+            border-radius: 0;
+          }
+          .card-group>.card:not(:first-child):not(:last-child):not(:only-child) .card-img-top,
+          .card-group>.card:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
+          .card-group>.card:not(:first-child):not(:last-child):not(:only-child) .card-header,
+          .card-group>.card:not(:first-child):not(:last-child):not(:only-child) .card-footer {
+            border-radius: 0;
+          }
+        }
+
+        .card-columns .card {
+          margin-bottom: 0.75rem;
+        }
+
+        @media (min-width: 576px) {
+          .card-columns {
+            -webkit-column-count: 3;
+            column-count: 3;
+            -webkit-column-gap: 1.25rem;
+            column-gap: 1.25rem;
+            orphans: 1;
+            widows: 1;
+          }
+          .card-columns .card {
+            display: inline-block;
+            width: 100%;
+          }
+        }
+
+        .accordion .card {
+          overflow: hidden;
+        }
+
+        .accordion .card:not(:first-of-type) .card-header:first-child {
+          border-radius: 0;
+        }
+
+        .accordion .card:not(:first-of-type):not(:last-of-type) {
+          border-bottom: 0;
+          border-radius: 0;
+        }
+
+        .accordion .card:first-of-type {
+          border-bottom: 0;
+          border-bottom-right-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+
+        .accordion .card:last-of-type {
+          border-top-left-radius: 0;
+          border-top-right-radius: 0;
+        }
+
+        .accordion .card .card-header {
+          margin-bottom: -1px;
+        }
+
+        .breadcrumb {
+          display: flex;
+          flex-wrap: wrap;
+          padding: 0.75rem 1rem;
+          margin-bottom: 1rem;
+          list-style: none;
+          background-color: #e9ecef;
+          border-radius: 0px;
+        }
+
+        .breadcrumb-item+.breadcrumb-item {
+          padding-left: 0.5rem;
+        }
+
+        .breadcrumb-item+.breadcrumb-item::before {
+          display: inline-block;
+          padding-right: 0.5rem;
+          color: #6c757d;
+          content: "/";
+        }
+
+        .breadcrumb-item+.breadcrumb-item:hover::before {
+          text-decoration: underline;
+        }
+
+        .breadcrumb-item+.breadcrumb-item:hover::before {
+          text-decoration: none;
+        }
+
+        .breadcrumb-item.active {
+          color: #6c757d;
+        }
+
+        .pagination {
+          display: flex;
+          padding-left: 0;
+          list-style: none;
+          border-radius: 0px;
+        }
+
+        .page-link {
+          position: relative;
+          display: block;
+          padding: 0.5rem 0.75rem;
+          margin-left: -1px;
+          line-height: 1.25;
+          color: #017FFD;
+          background-color: #FFFFFF;
+          border: 1px solid #dee2e6;
+        }
+
+        .page-link:hover {
+          z-index: 2;
+          color: #0159b1;
+          text-decoration: none;
+          background-color: #e9ecef;
+          border-color: #dee2e6;
+        }
+
+        .page-link:focus {
+          z-index: 2;
+          outline: 0;
+          box-shadow: 0 0 0 0.2rem rgba(1, 127, 253, 0.25);
+        }
+
+        .page-link:not(:disabled):not(.disabled) {
+          cursor: pointer;
+        }
+
+        .page-item:first-child .page-link {
+          margin-left: 0;
+          border-top-left-radius: 0px;
+          border-bottom-left-radius: 0px;
+        }
+
+        .page-item:last-child .page-link {
+          border-top-right-radius: 0px;
+          border-bottom-right-radius: 0px;
+        }
+
+        .page-item.active .page-link {
+          z-index: 1;
+          color: #FFFFFF;
+          background-color: #017FFD;
+          border-color: #017FFD;
+        }
+
+        .page-item.disabled .page-link {
+          color: #6c757d;
+          pointer-events: none;
+          cursor: auto;
+          background-color: #FFFFFF;
+          border-color: #dee2e6;
+        }
+
+        .pagination-lg .page-link {
+          padding: 0.75rem 1.5rem;
+          font-size: 1.25rem;
+          line-height: 1.5;
+        }
+
+        .pagination-lg .page-item:first-child .page-link {
+          border-top-left-radius: 0.3rem;
+          border-bottom-left-radius: 0.3rem;
+        }
+
+        .pagination-lg .page-item:last-child .page-link {
+          border-top-right-radius: 0.3rem;
+          border-bottom-right-radius: 0.3rem;
+        }
+
+        .pagination-sm .page-link {
+          padding: 0.25rem 0.5rem;
+          font-size: 0.875rem;
+          line-height: 1.5;
+        }
+
+        .pagination-sm .page-item:first-child .page-link {
+          border-top-left-radius: 0.2rem;
+          border-bottom-left-radius: 0.2rem;
+        }
+
+        .pagination-sm .page-item:last-child .page-link {
+          border-top-right-radius: 0.2rem;
+          border-bottom-right-radius: 0.2rem;
+        }
+
+        .badge {
+          display: inline-block;
+          padding: 0.25em 0.4em;
+          font-size: 75%;
+          font-weight: 700;
+          line-height: 1;
+          text-align: center;
+          white-space: nowrap;
+          vertical-align: baseline;
+          border-radius: 0px;
+        }
+
+        a.badge:hover,
+        a.badge:focus {
+          text-decoration: none;
+        }
+
+        .badge:empty {
+          display: none;
+        }
+
+        .btn .badge {
+          position: relative;
+          top: -1px;
+        }
+
+        .badge-pill {
+          padding-right: 0.6em;
+          padding-left: 0.6em;
+          border-radius: 10rem;
+        }
+
+        .badge-primary {
+          color: #FFFFFF;
+          background-color: #017FFD;
+        }
+
+        a.badge-primary:hover,
+        a.badge-primary:focus {
+          color: #FFFFFF;
+          background-color: #0166ca;
+        }
+
+        .badge-secondary {
+          color: #FFFFFF;
+          background-color: #005EC4;
+        }
+
+        a.badge-secondary:hover,
+        a.badge-secondary:focus {
+          color: #FFFFFF;
+          background-color: #004691;
+        }
+
+        .badge-success {
+          color: #FFFFFF;
+          background-color: #00BD55;
+        }
+
+        a.badge-success:hover,
+        a.badge-success:focus {
+          color: #FFFFFF;
+          background-color: #008a3e;
+        }
+
+        .badge-info {
+          color: #FFFFFF;
+          background-color: #17a2b8;
+        }
+
+        a.badge-info:hover,
+        a.badge-info:focus {
+          color: #FFFFFF;
+          background-color: #117a8b;
+        }
+
+        .badge-warning {
+          color: #212529;
+          background-color: #ffc107;
+        }
+
+        a.badge-warning:hover,
+        a.badge-warning:focus {
+          color: #212529;
+          background-color: #d39e00;
+        }
+
+        .badge-danger {
+          color: #FFFFFF;
+          background-color: #F36969;
+        }
+
+        a.badge-danger:hover,
+        a.badge-danger:focus {
+          color: #FFFFFF;
+          background-color: #ef3a3a;
+        }
+
+        .badge-light {
+          color: #212529;
+          background-color: #FFFFFF;
+        }
+
+        a.badge-light:hover,
+        a.badge-light:focus {
+          color: #212529;
+          background-color: #e6e6e6;
+        }
+
+        .badge-dark {
+          color: #FFFFFF;
+          background-color: #353535;
+        }
+
+        a.badge-dark:hover,
+        a.badge-dark:focus {
+          color: #FFFFFF;
+          background-color: #1c1c1c;
+        }
+
+        .jumbotron {
+          padding: 2rem 1rem;
+          margin-bottom: 2rem;
+          background-color: #e9ecef;
+          border-radius: 0.3rem;
+        }
+
+        @media (min-width: 576px) {
+          .jumbotron {
+            padding: 4rem 2rem;
+          }
+        }
+
+        .jumbotron-fluid {
+          padding-right: 0;
+          padding-left: 0;
+          border-radius: 0;
+        }
+
+        .alert {
+          position: relative;
+          padding: 0.75rem 1.25rem;
+          margin-bottom: 1rem;
+          border: 1px solid transparent;
+          border-radius: 0px;
+        }
+
+        .alert-heading {
+          color: inherit;
+        }
+
+        .alert-link {
+          font-weight: 700;
+        }
+
+        .alert-dismissible {
+          padding-right: 4rem;
+        }
+
+        .alert-dismissible .close {
+          position: absolute;
+          top: 0;
+          right: 0;
+          padding: 0.75rem 1.25rem;
+          color: inherit;
+        }
+
+        .alert-primary {
+          color: #014284;
+          background-color: #cce5ff;
+          border-color: #b8dbfe;
+        }
+
+        .alert-primary hr {
+          border-top-color: #9fcefe;
+        }
+
+        .alert-primary .alert-link {
+          color: #012951;
+        }
+
+        .alert-secondary {
+          color: #003166;
+          background-color: #ccdff3;
+          border-color: #b8d2ee;
+        }
+
+        .alert-secondary hr {
+          border-top-color: #a3c5e9;
+        }
+
+        .alert-secondary .alert-link {
+          color: #001933;
+        }
+
+        .alert-success {
+          color: #00622c;
+          background-color: #ccf2dd;
+          border-color: #b8edcf;
+        }
+
+        .alert-success hr {
+          border-top-color: #a4e8c1;
+        }
+
+        .alert-success .alert-link {
+          color: #002f15;
+        }
+
+        .alert-info {
+          color: #0c5460;
+          background-color: #d1ecf1;
+          border-color: #bee5eb;
+        }
+
+        .alert-info hr {
+          border-top-color: #abdde5;
+        }
+
+        .alert-info .alert-link {
+          color: #062c33;
+        }
+
+        .alert-warning {
+          color: #856404;
+          background-color: #fff3cd;
+          border-color: #ffeeba;
+        }
+
+        .alert-warning hr {
+          border-top-color: #ffe8a1;
+        }
+
+        .alert-warning .alert-link {
+          color: #533f03;
+        }
+
+        .alert-danger {
+          color: #7e3737;
+          background-color: #fde1e1;
+          border-color: #fcd5d5;
+        }
+
+        .alert-danger hr {
+          border-top-color: #fabdbd;
+        }
+
+        .alert-danger .alert-link {
+          color: #5a2828;
+        }
+
+        .alert-light {
+          color: #858585;
+          background-color: white;
+          border-color: white;
+        }
+
+        .alert-light hr {
+          border-top-color: #f2f2f2;
+        }
+
+        .alert-light .alert-link {
+          color: #6c6c6c;
+        }
+
+        .alert-dark {
+          color: #1c1c1c;
+          background-color: #d7d7d7;
+          border-color: #c6c6c6;
+        }
+
+        .alert-dark hr {
+          border-top-color: #b9b9b9;
+        }
+
+        .alert-dark .alert-link {
+          color: #030303;
+        }
+
+        @-webkit-keyframes progress-bar-stripes {
+          from {
+            background-position: 1rem 0;
+          }
+          to {
+            background-position: 0 0;
+          }
+        }
+
+        @keyframes progress-bar-stripes {
+          from {
+            background-position: 1rem 0;
+          }
+          to {
+            background-position: 0 0;
+          }
+        }
+
+        .progress {
+          display: flex;
+          height: 1rem;
+          overflow: hidden;
+          font-size: 0.75rem;
+          background-color: #e9ecef;
+          border-radius: 0px;
+        }
+
+        .progress-bar {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          color: #FFFFFF;
+          text-align: center;
+          white-space: nowrap;
+          background-color: #017FFD;
+          transition: width 0.6s ease;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .progress-bar {
+            transition: none;
+          }
+        }
+
+        .progress-bar-striped {
+          background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+          background-size: 1rem 1rem;
+        }
+
+        .progress-bar-animated {
+          -webkit-animation: progress-bar-stripes 1s linear infinite;
+          animation: progress-bar-stripes 1s linear infinite;
+        }
+
+        .media {
+          display: flex;
+          align-items: flex-start;
+        }
+
+        .media-body {
+          flex: 1;
+        }
+
+        .list-group {
+          display: flex;
+          flex-direction: column;
+          padding-left: 0;
+          margin-bottom: 0;
+        }
+
+        .list-group-item-action {
+          width: 100%;
+          color: #495057;
+          text-align: inherit;
+        }
+
+        .list-group-item-action:hover,
+        .list-group-item-action:focus {
+          color: #495057;
+          text-decoration: none;
+          background-color: #f8f9fa;
+        }
+
+        .list-group-item-action:active {
+          color: #212529;
+          background-color: #e9ecef;
+        }
+
+        .list-group-item {
+          position: relative;
+          display: block;
+          padding: 0.75rem 1.25rem;
+          margin-bottom: -1px;
+          background-color: #FFFFFF;
+          border: 1px solid rgba(0, 0, 0, 0.125);
+        }
+
+        .list-group-item:first-child {
+          border-top-left-radius: 0px;
+          border-top-right-radius: 0px;
+        }
+
+        .list-group-item:last-child {
+          margin-bottom: 0;
+          border-bottom-right-radius: 0px;
+          border-bottom-left-radius: 0px;
+        }
+
+        .list-group-item:hover,
+        .list-group-item:focus {
+          z-index: 1;
+          text-decoration: none;
+        }
+
+        .list-group-item.disabled,
+        .list-group-item:disabled {
+          color: #6c757d;
+          pointer-events: none;
+          background-color: #FFFFFF;
+        }
+
+        .list-group-item.active {
+          z-index: 2;
+          color: #FFFFFF;
+          background-color: #017FFD;
+          border-color: #017FFD;
+        }
+
+        .list-group-flush .list-group-item {
+          border-right: 0;
+          border-left: 0;
+          border-radius: 0;
+        }
+
+        .list-group-flush .list-group-item:last-child {
+          margin-bottom: -1px;
+        }
+
+        .list-group-flush:first-child .list-group-item:first-child {
+          border-top: 0;
+        }
+
+        .list-group-flush:last-child .list-group-item:last-child {
+          margin-bottom: 0;
+          border-bottom: 0;
+        }
+
+        .list-group-item-primary {
+          color: #014284;
+          background-color: #b8dbfe;
+        }
+
+        .list-group-item-primary.list-group-item-action:hover,
+        .list-group-item-primary.list-group-item-action:focus {
+          color: #014284;
+          background-color: #9fcefe;
+        }
+
+        .list-group-item-primary.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #014284;
+          border-color: #014284;
+        }
+
+        .list-group-item-secondary {
+          color: #003166;
+          background-color: #b8d2ee;
+        }
+
+        .list-group-item-secondary.list-group-item-action:hover,
+        .list-group-item-secondary.list-group-item-action:focus {
+          color: #003166;
+          background-color: #a3c5e9;
+        }
+
+        .list-group-item-secondary.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #003166;
+          border-color: #003166;
+        }
+
+        .list-group-item-success {
+          color: #00622c;
+          background-color: #b8edcf;
+        }
+
+        .list-group-item-success.list-group-item-action:hover,
+        .list-group-item-success.list-group-item-action:focus {
+          color: #00622c;
+          background-color: #a4e8c1;
+        }
+
+        .list-group-item-success.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #00622c;
+          border-color: #00622c;
+        }
+
+        .list-group-item-info {
+          color: #0c5460;
+          background-color: #bee5eb;
+        }
+
+        .list-group-item-info.list-group-item-action:hover,
+        .list-group-item-info.list-group-item-action:focus {
+          color: #0c5460;
+          background-color: #abdde5;
+        }
+
+        .list-group-item-info.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #0c5460;
+          border-color: #0c5460;
+        }
+
+        .list-group-item-warning {
+          color: #856404;
+          background-color: #ffeeba;
+        }
+
+        .list-group-item-warning.list-group-item-action:hover,
+        .list-group-item-warning.list-group-item-action:focus {
+          color: #856404;
+          background-color: #ffe8a1;
+        }
+
+        .list-group-item-warning.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #856404;
+          border-color: #856404;
+        }
+
+        .list-group-item-danger {
+          color: #7e3737;
+          background-color: #fcd5d5;
+        }
+
+        .list-group-item-danger.list-group-item-action:hover,
+        .list-group-item-danger.list-group-item-action:focus {
+          color: #7e3737;
+          background-color: #fabdbd;
+        }
+
+        .list-group-item-danger.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #7e3737;
+          border-color: #7e3737;
+        }
+
+        .list-group-item-light {
+          color: #858585;
+          background-color: white;
+        }
+
+        .list-group-item-light.list-group-item-action:hover,
+        .list-group-item-light.list-group-item-action:focus {
+          color: #858585;
+          background-color: #f2f2f2;
+        }
+
+        .list-group-item-light.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #858585;
+          border-color: #858585;
+        }
+
+        .list-group-item-dark {
+          color: #1c1c1c;
+          background-color: #c6c6c6;
+        }
+
+        .list-group-item-dark.list-group-item-action:hover,
+        .list-group-item-dark.list-group-item-action:focus {
+          color: #1c1c1c;
+          background-color: #b9b9b9;
+        }
+
+        .list-group-item-dark.list-group-item-action.active {
+          color: #FFFFFF;
+          background-color: #1c1c1c;
+          border-color: #1c1c1c;
+        }
+
+        .close {
+          float: right;
+          font-size: 1.5rem;
+          font-weight: 700;
+          line-height: 1;
+          color: #000;
+          text-shadow: 0 1px 0 #FFFFFF;
+          opacity: .5;
+        }
+
+        .close:hover {
+          color: #000;
+          text-decoration: none;
+        }
+
+        .close:not(:disabled):not(.disabled) {
+          cursor: pointer;
+        }
+
+        .close:not(:disabled):not(.disabled):hover,
+        .close:not(:disabled):not(.disabled):focus {
+          opacity: .75;
+        }
+
+        button.close {
+          padding: 0;
+          background-color: transparent;
+          border: 0;
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          appearance: none;
+        }
+
+        a.close.disabled {
+          pointer-events: none;
+        }
+
+        .toast {
+          max-width: 350px;
+          overflow: hidden;
+          font-size: 0.875rem;
+          background-color: rgba(255, 255, 255, 0.85);
+          background-clip: padding-box;
+          border: 1px solid rgba(0, 0, 0, 0.1);
+          border-radius: 0.25rem;
+          box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
+          -webkit-backdrop-filter: blur(10px);
+          backdrop-filter: blur(10px);
+          opacity: 0;
+        }
+
+        .toast:not(:last-child) {
+          margin-bottom: 0.75rem;
+        }
+
+        .toast.showing {
+          opacity: 1;
+        }
+
+        .toast.show {
+          display: block;
+          opacity: 1;
+        }
+
+        .toast.hide {
+          display: none;
+        }
+
+        .toast-header {
+          display: flex;
+          align-items: center;
+          padding: 0.25rem 0.75rem;
+          color: #6c757d;
+          background-color: rgba(255, 255, 255, 0.85);
+          background-clip: padding-box;
+          border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+        }
+
+        .toast-body {
+          padding: 0.75rem;
+        }
+
+        .modal-open {
+          overflow: hidden;
+        }
+
+        .modal-open .modal {
+          overflow-x: hidden;
+          overflow-y: auto;
+        }
+
+        .modal {
+          position: fixed;
+          top: 0;
+          left: 0;
+          z-index: 1050;
+          display: none;
+          width: 100%;
+          height: 100%;
+          overflow: hidden;
+          outline: 0;
+        }
+
+        .modal-dialog {
+          position: relative;
+          width: auto;
+          margin: 0.5rem;
+          pointer-events: none;
+        }
+
+        .modal.fade .modal-dialog {
+          transition: -webkit-transform 0.3s ease-out;
+          transition: transform 0.3s ease-out;
+          transition: transform 0.3s ease-out, -webkit-transform 0.3s ease-out;
+          -webkit-transform: translate(0, -50px);
+          transform: translate(0, -50px);
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .modal.fade .modal-dialog {
+            transition: none;
+          }
+        }
+
+        .modal.show .modal-dialog {
+          -webkit-transform: none;
+          transform: none;
+        }
+
+        .modal-dialog-centered {
+          display: flex;
+          align-items: center;
+          min-height: calc(100% - (0.5rem * 2));
+        }
+
+        .modal-dialog-centered::before {
+          display: block;
+          height: calc(100vh - (0.5rem * 2));
+          content: "";
+        }
+
+        .modal-content {
+          position: relative;
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+          pointer-events: auto;
+          background-color: #FFFFFF;
+          background-clip: padding-box;
+          border: 1px solid rgba(0, 0, 0, 0.2);
+          border-radius: 0.3rem;
+          outline: 0;
+        }
+
+        .modal-backdrop {
+          position: fixed;
+          top: 0;
+          left: 0;
+          z-index: 1040;
+          width: 100vw;
+          height: 100vh;
+          background-color: #000;
+        }
+
+        .modal-backdrop.fade {
+          opacity: 0;
+        }
+
+        .modal-backdrop.show {
+          opacity: 0.5;
+        }
+
+        .modal-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          padding: 1rem 1rem;
+          border-bottom: 1px solid #e9ecef;
+          border-top-left-radius: 0.3rem;
+          border-top-right-radius: 0.3rem;
+        }
+
+        .modal-header .close {
+          padding: 1rem 1rem;
+          margin: -1rem -1rem -1rem auto;
+        }
+
+        .modal-title {
+          margin-bottom: 0;
+          line-height: 1.5;
+        }
+
+        .modal-body {
+          position: relative;
+          flex: 1 1 auto;
+          padding: 1rem;
+        }
+
+        .modal-footer {
+          display: flex;
+          align-items: center;
+          justify-content: flex-end;
+          padding: 1rem;
+          border-top: 1px solid #e9ecef;
+          border-bottom-right-radius: 0.3rem;
+          border-bottom-left-radius: 0.3rem;
+        }
+
+        .modal-footer> :not(:first-child) {
+          margin-left: .25rem;
+        }
+
+        .modal-footer> :not(:last-child) {
+          margin-right: .25rem;
+        }
+
+        .modal-scrollbar-measure {
+          position: absolute;
+          top: -9999px;
+          width: 50px;
+          height: 50px;
+          overflow: scroll;
+        }
+
+        @media (min-width: 576px) {
+          .modal-dialog {
+            max-width: 500px;
+            margin: 1.75rem auto;
+          }
+          .modal-dialog-centered {
+            min-height: calc(100% - (1.75rem * 2));
+          }
+          .modal-dialog-centered::before {
+            height: calc(100vh - (1.75rem * 2));
+          }
+          .modal-sm {
+            max-width: 300px;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .modal-lg,
+          .modal-xl {
+            max-width: 800px;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .modal-xl {
+            max-width: 1140px;
+          }
+        }
+
+        .tooltip {
+          position: absolute;
+          z-index: 1070;
+          display: block;
+          margin: 0;
+          font-family: "IBM Plex Sans";
+          font-style: normal;
+          font-weight: 400;
+          line-height: 1.5;
+          text-align: left;
+          text-align: start;
+          text-decoration: none;
+          text-shadow: none;
+          text-transform: none;
+          letter-spacing: normal;
+          word-break: normal;
+          word-spacing: normal;
+          white-space: normal;
+          line-break: auto;
+          font-size: 0.875rem;
+          word-wrap: break-word;
+          opacity: 0;
+        }
+
+        .tooltip.show {
+          opacity: 0.9;
+        }
+
+        .tooltip .arrow {
+          position: absolute;
+          display: block;
+          width: 0.8rem;
+          height: 0.4rem;
+        }
+
+        .tooltip .arrow::before {
+          position: absolute;
+          content: "";
+          border-color: transparent;
+          border-style: solid;
+        }
+
+        .bs-tooltip-top,
+        .bs-tooltip-auto[x-placement^="top"] {
+          padding: 0.4rem 0;
+        }
+
+        .bs-tooltip-top .arrow,
+        .bs-tooltip-auto[x-placement^="top"] .arrow {
+          bottom: 0;
+        }
+
+        .bs-tooltip-top .arrow::before,
+        .bs-tooltip-auto[x-placement^="top"] .arrow::before {
+          top: 0;
+          border-width: 0.4rem 0.4rem 0;
+          border-top-color: #000;
+        }
+
+        .bs-tooltip-right,
+        .bs-tooltip-auto[x-placement^="right"] {
+          padding: 0 0.4rem;
+        }
+
+        .bs-tooltip-right .arrow,
+        .bs-tooltip-auto[x-placement^="right"] .arrow {
+          left: 0;
+          width: 0.4rem;
+          height: 0.8rem;
+        }
+
+        .bs-tooltip-right .arrow::before,
+        .bs-tooltip-auto[x-placement^="right"] .arrow::before {
+          right: 0;
+          border-width: 0.4rem 0.4rem 0.4rem 0;
+          border-right-color: #000;
+        }
+
+        .bs-tooltip-bottom,
+        .bs-tooltip-auto[x-placement^="bottom"] {
+          padding: 0.4rem 0;
+        }
+
+        .bs-tooltip-bottom .arrow,
+        .bs-tooltip-auto[x-placement^="bottom"] .arrow {
+          top: 0;
+        }
+
+        .bs-tooltip-bottom .arrow::before,
+        .bs-tooltip-auto[x-placement^="bottom"] .arrow::before {
+          bottom: 0;
+          border-width: 0 0.4rem 0.4rem;
+          border-bottom-color: #000;
+        }
+
+        .bs-tooltip-left,
+        .bs-tooltip-auto[x-placement^="left"] {
+          padding: 0 0.4rem;
+        }
+
+        .bs-tooltip-left .arrow,
+        .bs-tooltip-auto[x-placement^="left"] .arrow {
+          right: 0;
+          width: 0.4rem;
+          height: 0.8rem;
+        }
+
+        .bs-tooltip-left .arrow::before,
+        .bs-tooltip-auto[x-placement^="left"] .arrow::before {
+          left: 0;
+          border-width: 0.4rem 0 0.4rem 0.4rem;
+          border-left-color: #000;
+        }
+
+        .tooltip-inner {
+          max-width: 200px;
+          padding: 0.25rem 0.5rem;
+          color: #FFFFFF;
+          text-align: center;
+          background-color: #000;
+          border-radius: 0px;
+        }
+
+        .popover {
+          position: absolute;
+          top: 0;
+          left: 0;
+          z-index: 1060;
+          display: block;
+          max-width: 276px;
+          font-family: "IBM Plex Sans";
+          font-style: normal;
+          font-weight: 400;
+          line-height: 1.5;
+          text-align: left;
+          text-align: start;
+          text-decoration: none;
+          text-shadow: none;
+          text-transform: none;
+          letter-spacing: normal;
+          word-break: normal;
+          word-spacing: normal;
+          white-space: normal;
+          line-break: auto;
+          font-size: 0.875rem;
+          word-wrap: break-word;
+          background-color: #FFFFFF;
+          background-clip: padding-box;
+          border: 1px solid rgba(0, 0, 0, 0.2);
+          border-radius: 0.3rem;
+        }
+
+        .popover .arrow {
+          position: absolute;
+          display: block;
+          width: 1rem;
+          height: 0.5rem;
+          margin: 0 0.3rem;
+        }
+
+        .popover .arrow::before,
+        .popover .arrow::after {
+          position: absolute;
+          display: block;
+          content: "";
+          border-color: transparent;
+          border-style: solid;
+        }
+
+        .bs-popover-top,
+        .bs-popover-auto[x-placement^="top"] {
+          margin-bottom: 0.5rem;
+        }
+
+        .bs-popover-top .arrow,
+        .bs-popover-auto[x-placement^="top"] .arrow {
+          bottom: calc((0.5rem + 1px) * -1);
+        }
+
+        .bs-popover-top .arrow::before,
+        .bs-popover-auto[x-placement^="top"] .arrow::before,
+        .bs-popover-top .arrow::after,
+        .bs-popover-auto[x-placement^="top"] .arrow::after {
+          border-width: 0.5rem 0.5rem 0;
+        }
+
+        .bs-popover-top .arrow::before,
+        .bs-popover-auto[x-placement^="top"] .arrow::before {
+          bottom: 0;
+          border-top-color: rgba(0, 0, 0, 0.25);
+        }
+
+        .bs-popover-top .arrow::after,
+        .bs-popover-auto[x-placement^="top"] .arrow::after {
+          bottom: 1px;
+          border-top-color: #FFFFFF;
+        }
+
+        .bs-popover-right,
+        .bs-popover-auto[x-placement^="right"] {
+          margin-left: 0.5rem;
+        }
+
+        .bs-popover-right .arrow,
+        .bs-popover-auto[x-placement^="right"] .arrow {
+          left: calc((0.5rem + 1px) * -1);
+          width: 0.5rem;
+          height: 1rem;
+          margin: 0.3rem 0;
+        }
+
+        .bs-popover-right .arrow::before,
+        .bs-popover-auto[x-placement^="right"] .arrow::before,
+        .bs-popover-right .arrow::after,
+        .bs-popover-auto[x-placement^="right"] .arrow::after {
+          border-width: 0.5rem 0.5rem 0.5rem 0;
+        }
+
+        .bs-popover-right .arrow::before,
+        .bs-popover-auto[x-placement^="right"] .arrow::before {
+          left: 0;
+          border-right-color: rgba(0, 0, 0, 0.25);
+        }
+
+        .bs-popover-right .arrow::after,
+        .bs-popover-auto[x-placement^="right"] .arrow::after {
+          left: 1px;
+          border-right-color: #FFFFFF;
+        }
+
+        .bs-popover-bottom,
+        .bs-popover-auto[x-placement^="bottom"] {
+          margin-top: 0.5rem;
+        }
+
+        .bs-popover-bottom .arrow,
+        .bs-popover-auto[x-placement^="bottom"] .arrow {
+          top: calc((0.5rem + 1px) * -1);
+        }
+
+        .bs-popover-bottom .arrow::before,
+        .bs-popover-auto[x-placement^="bottom"] .arrow::before,
+        .bs-popover-bottom .arrow::after,
+        .bs-popover-auto[x-placement^="bottom"] .arrow::after {
+          border-width: 0 0.5rem 0.5rem 0.5rem;
+        }
+
+        .bs-popover-bottom .arrow::before,
+        .bs-popover-auto[x-placement^="bottom"] .arrow::before {
+          top: 0;
+          border-bottom-color: rgba(0, 0, 0, 0.25);
+        }
+
+        .bs-popover-bottom .arrow::after,
+        .bs-popover-auto[x-placement^="bottom"] .arrow::after {
+          top: 1px;
+          border-bottom-color: #FFFFFF;
+        }
+
+        .bs-popover-bottom .popover-header::before,
+        .bs-popover-auto[x-placement^="bottom"] .popover-header::before {
+          position: absolute;
+          top: 0;
+          left: 50%;
+          display: block;
+          width: 1rem;
+          margin-left: -0.5rem;
+          content: "";
+          border-bottom: 1px solid #f7f7f7;
+        }
+
+        .bs-popover-left,
+        .bs-popover-auto[x-placement^="left"] {
+          margin-right: 0.5rem;
+        }
+
+        .bs-popover-left .arrow,
+        .bs-popover-auto[x-placement^="left"] .arrow {
+          right: calc((0.5rem + 1px) * -1);
+          width: 0.5rem;
+          height: 1rem;
+          margin: 0.3rem 0;
+        }
+
+        .bs-popover-left .arrow::before,
+        .bs-popover-auto[x-placement^="left"] .arrow::before,
+        .bs-popover-left .arrow::after,
+        .bs-popover-auto[x-placement^="left"] .arrow::after {
+          border-width: 0.5rem 0 0.5rem 0.5rem;
+        }
+
+        .bs-popover-left .arrow::before,
+        .bs-popover-auto[x-placement^="left"] .arrow::before {
+          right: 0;
+          border-left-color: rgba(0, 0, 0, 0.25);
+        }
+
+        .bs-popover-left .arrow::after,
+        .bs-popover-auto[x-placement^="left"] .arrow::after {
+          right: 1px;
+          border-left-color: #FFFFFF;
+        }
+
+        .popover-header {
+          padding: 0.5rem 0.75rem;
+          margin-bottom: 0;
+          font-size: 1rem;
+          color: inherit;
+          background-color: #f7f7f7;
+          border-bottom: 1px solid #ebebeb;
+          border-top-left-radius: calc(0.3rem - 1px);
+          border-top-right-radius: calc(0.3rem - 1px);
+        }
+
+        .popover-header:empty {
+          display: none;
+        }
+
+        .popover-body {
+          padding: 0.5rem 0.75rem;
+          color: #212529;
+        }
+
+        .carousel {
+          position: relative;
+        }
+
+        .carousel.pointer-event {
+          touch-action: pan-y;
+        }
+
+        .carousel-inner {
+          position: relative;
+          width: 100%;
+          overflow: hidden;
+        }
+
+        .carousel-inner::after {
+          display: block;
+          clear: both;
+          content: "";
+        }
+
+        .carousel-item {
+          position: relative;
+          display: none;
+          float: left;
+          width: 100%;
+          margin-right: -100%;
+          -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
+          transition: -webkit-transform 0.6s ease-in-out;
+          transition: transform 0.6s ease-in-out;
+          transition: transform 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .carousel-item {
+            transition: none;
+          }
+        }
+
+        .carousel-item.active,
+        .carousel-item-next,
+        .carousel-item-prev {
+          display: block;
+        }
+
+        .carousel-item-next:not(.carousel-item-left),
+        .active.carousel-item-right {
+          -webkit-transform: translateX(100%);
+          transform: translateX(100%);
+        }
+
+        .carousel-item-prev:not(.carousel-item-right),
+        .active.carousel-item-left {
+          -webkit-transform: translateX(-100%);
+          transform: translateX(-100%);
+        }
+
+        .carousel-fade .carousel-item {
+          opacity: 0;
+          transition-property: opacity;
+          -webkit-transform: none;
+          transform: none;
+        }
+
+        .carousel-fade .carousel-item.active,
+        .carousel-fade .carousel-item-next.carousel-item-left,
+        .carousel-fade .carousel-item-prev.carousel-item-right {
+          z-index: 1;
+          opacity: 1;
+        }
+
+        .carousel-fade .active.carousel-item-left,
+        .carousel-fade .active.carousel-item-right {
+          z-index: 0;
+          opacity: 0;
+          transition: 0s 0.6s opacity;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .carousel-fade .active.carousel-item-left,
+          .carousel-fade .active.carousel-item-right {
+            transition: none;
+          }
+        }
+
+        .carousel-control-prev,
+        .carousel-control-next {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          z-index: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 15%;
+          color: #FFFFFF;
+          text-align: center;
+          opacity: 0.5;
+          transition: opacity 0.15s ease;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .carousel-control-prev,
+          .carousel-control-next {
+            transition: none;
+          }
+        }
+
+        .carousel-control-prev:hover,
+        .carousel-control-prev:focus,
+        .carousel-control-next:hover,
+        .carousel-control-next:focus {
+          color: #FFFFFF;
+          text-decoration: none;
+          outline: 0;
+          opacity: 0.9;
+        }
+
+        .carousel-control-prev {
+          left: 0;
+        }
+
+        .carousel-control-next {
+          right: 0;
+        }
+
+        .carousel-control-prev-icon,
+        .carousel-control-next-icon {
+          display: inline-block;
+          width: 20px;
+          height: 20px;
+          background: transparent no-repeat center center;
+          background-size: 100% 100%;
+        }
+
+        .carousel-control-prev-icon {
+          background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e");
+        }
+
+        .carousel-control-next-icon {
+          background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23FFFFFF' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e");
+        }
+
+        .carousel-indicators {
+          position: absolute;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          z-index: 15;
+          display: flex;
+          justify-content: center;
+          padding-left: 0;
+          margin-right: 15%;
+          margin-left: 15%;
+          list-style: none;
+        }
+
+        .carousel-indicators li {
+          box-sizing: content-box;
+          flex: 0 1 auto;
+          width: 30px;
+          height: 3px;
+          margin-right: 3px;
+          margin-left: 3px;
+          text-indent: -999px;
+          cursor: pointer;
+          background-color: #FFFFFF;
+          background-clip: padding-box;
+          border-top: 10px solid transparent;
+          border-bottom: 10px solid transparent;
+          opacity: .5;
+          transition: opacity 0.6s ease;
+        }
+
+        @media screen and (prefers-reduced-motion: reduce) {
+          .carousel-indicators li {
+            transition: none;
+          }
+        }
+
+        .carousel-indicators .active {
+          opacity: 1;
+        }
+
+        .carousel-caption {
+          position: absolute;
+          right: 15%;
+          bottom: 20px;
+          left: 15%;
+          z-index: 10;
+          padding-top: 20px;
+          padding-bottom: 20px;
+          color: #FFFFFF;
+          text-align: center;
+        }
+
+        @-webkit-keyframes spinner-border {
+          to {
+            -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+          }
+        }
+
+        @keyframes spinner-border {
+          to {
+            -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+          }
+        }
+
+        .spinner-border {
+          display: inline-block;
+          width: 2rem;
+          height: 2rem;
+          vertical-align: text-bottom;
+          border: 0.25em solid currentColor;
+          border-right-color: transparent;
+          border-radius: 50%;
+          -webkit-animation: spinner-border .75s linear infinite;
+          animation: spinner-border .75s linear infinite;
+        }
+
+        .spinner-border-sm {
+          width: 1rem;
+          height: 1rem;
+          border-width: 0.2em;
+        }
+
+        @-webkit-keyframes spinner-grow {
+          0% {
+            -webkit-transform: scale(0);
+            transform: scale(0);
+          }
+          50% {
+            opacity: 1;
+          }
+        }
+
+        @keyframes spinner-grow {
+          0% {
+            -webkit-transform: scale(0);
+            transform: scale(0);
+          }
+          50% {
+            opacity: 1;
+          }
+        }
+
+        .spinner-grow {
+          display: inline-block;
+          width: 2rem;
+          height: 2rem;
+          vertical-align: text-bottom;
+          background-color: currentColor;
+          border-radius: 50%;
+          opacity: 0;
+          -webkit-animation: spinner-grow .75s linear infinite;
+          animation: spinner-grow .75s linear infinite;
+        }
+
+        .spinner-grow-sm {
+          width: 1rem;
+          height: 1rem;
+        }
+
+        .align-baseline {
+          vertical-align: baseline !important;
+        }
+
+        .align-top {
+          vertical-align: top !important;
+        }
+
+        .align-middle {
+          vertical-align: middle !important;
+        }
+
+        .align-bottom {
+          vertical-align: bottom !important;
+        }
+
+        .align-text-bottom {
+          vertical-align: text-bottom !important;
+        }
+
+        .align-text-top {
+          vertical-align: text-top !important;
+        }
+
+        .bg-primary {
+          background-color: #017FFD !important;
+        }
+
+        a.bg-primary:hover,
+        a.bg-primary:focus,
+        button.bg-primary:hover,
+        button.bg-primary:focus {
+          background-color: #0166ca !important;
+        }
+
+        .bg-secondary {
+          background-color: #005EC4 !important;
+        }
+
+        a.bg-secondary:hover,
+        a.bg-secondary:focus,
+        button.bg-secondary:hover,
+        button.bg-secondary:focus {
+          background-color: #004691 !important;
+        }
+
+        .bg-success {
+          background-color: #00BD55 !important;
+        }
+
+        a.bg-success:hover,
+        a.bg-success:focus,
+        button.bg-success:hover,
+        button.bg-success:focus {
+          background-color: #008a3e !important;
+        }
+
+        .bg-info {
+          background-color: #17a2b8 !important;
+        }
+
+        a.bg-info:hover,
+        a.bg-info:focus,
+        button.bg-info:hover,
+        button.bg-info:focus {
+          background-color: #117a8b !important;
+        }
+
+        .bg-warning {
+          background-color: #ffc107 !important;
+        }
+
+        a.bg-warning:hover,
+        a.bg-warning:focus,
+        button.bg-warning:hover,
+        button.bg-warning:focus {
+          background-color: #d39e00 !important;
+        }
+
+        .bg-danger {
+          background-color: #F36969 !important;
+        }
+
+        a.bg-danger:hover,
+        a.bg-danger:focus,
+        button.bg-danger:hover,
+        button.bg-danger:focus {
+          background-color: #ef3a3a !important;
+        }
+
+        .bg-light {
+          background-color: #FFFFFF !important;
+        }
+
+        a.bg-light:hover,
+        a.bg-light:focus,
+        button.bg-light:hover,
+        button.bg-light:focus {
+          background-color: #e6e6e6 !important;
+        }
+
+        .bg-dark {
+          background-color: #353535 !important;
+        }
+
+        a.bg-dark:hover,
+        a.bg-dark:focus,
+        button.bg-dark:hover,
+        button.bg-dark:focus {
+          background-color: #1c1c1c !important;
+        }
+
+        .bg-white {
+          background-color: #FFFFFF !important;
+        }
+
+        .bg-transparent {
+          background-color: transparent !important;
+        }
+
+        .border {
+          border: 1px solid #dee2e6 !important;
+        }
+
+        .border-top {
+          border-top: 1px solid #dee2e6 !important;
+        }
+
+        .border-right {
+          border-right: 1px solid #dee2e6 !important;
+        }
+
+        .border-bottom {
+          border-bottom: 1px solid #dee2e6 !important;
+        }
+
+        .border-left {
+          border-left: 1px solid #dee2e6 !important;
+        }
+
+        .border-0 {
+          border: 0 !important;
+        }
+
+        .border-top-0 {
+          border-top: 0 !important;
+        }
+
+        .border-right-0 {
+          border-right: 0 !important;
+        }
+
+        .border-bottom-0 {
+          border-bottom: 0 !important;
+        }
+
+        .border-left-0 {
+          border-left: 0 !important;
+        }
+
+        .border-primary {
+          border-color: #017FFD !important;
+        }
+
+        .border-secondary {
+          border-color: #005EC4 !important;
+        }
+
+        .border-success {
+          border-color: #00BD55 !important;
+        }
+
+        .border-info {
+          border-color: #17a2b8 !important;
+        }
+
+        .border-warning {
+          border-color: #ffc107 !important;
+        }
+
+        .border-danger {
+          border-color: #F36969 !important;
+        }
+
+        .border-light {
+          border-color: #FFFFFF !important;
+        }
+
+        .border-dark {
+          border-color: #353535 !important;
+        }
+
+        .border-white {
+          border-color: #FFFFFF !important;
+        }
+
+        .rounded {
+          border-radius: 0px !important;
+        }
+
+        .rounded-top {
+          border-top-left-radius: 0px !important;
+          border-top-right-radius: 0px !important;
+        }
+
+        .rounded-right {
+          border-top-right-radius: 0px !important;
+          border-bottom-right-radius: 0px !important;
+        }
+
+        .rounded-bottom {
+          border-bottom-right-radius: 0px !important;
+          border-bottom-left-radius: 0px !important;
+        }
+
+        .rounded-left {
+          border-top-left-radius: 0px !important;
+          border-bottom-left-radius: 0px !important;
+        }
+
+        .rounded-circle {
+          border-radius: 50% !important;
+        }
+
+        .rounded-pill {
+          border-radius: 50rem !important;
+        }
+
+        .rounded-0 {
+          border-radius: 0 !important;
+        }
+
+        .clearfix::after {
+          display: block;
+          clear: both;
+          content: "";
+        }
+
+        .d-none {
+          display: none !important;
+        }
+
+        .d-inline {
+          display: inline !important;
+        }
+
+        .d-inline-block {
+          display: inline-block !important;
+        }
+
+        .d-block {
+          display: block !important;
+        }
+
+        .d-table {
+          display: table !important;
+        }
+
+        .d-table-row {
+          display: table-row !important;
+        }
+
+        .d-table-cell {
+          display: table-cell !important;
+        }
+
+        .d-flex {
+          display: flex !important;
+        }
+
+        .d-inline-flex {
+          display: inline-flex !important;
+        }
+
+        @media (min-width: 576px) {
+          .d-sm-none {
+            display: none !important;
+          }
+          .d-sm-inline {
+            display: inline !important;
+          }
+          .d-sm-inline-block {
+            display: inline-block !important;
+          }
+          .d-sm-block {
+            display: block !important;
+          }
+          .d-sm-table {
+            display: table !important;
+          }
+          .d-sm-table-row {
+            display: table-row !important;
+          }
+          .d-sm-table-cell {
+            display: table-cell !important;
+          }
+          .d-sm-flex {
+            display: flex !important;
+          }
+          .d-sm-inline-flex {
+            display: inline-flex !important;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .d-md-none {
+            display: none !important;
+          }
+          .d-md-inline {
+            display: inline !important;
+          }
+          .d-md-inline-block {
+            display: inline-block !important;
+          }
+          .d-md-block {
+            display: block !important;
+          }
+          .d-md-table {
+            display: table !important;
+          }
+          .d-md-table-row {
+            display: table-row !important;
+          }
+          .d-md-table-cell {
+            display: table-cell !important;
+          }
+          .d-md-flex {
+            display: flex !important;
+          }
+          .d-md-inline-flex {
+            display: inline-flex !important;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .d-lg-none {
+            display: none !important;
+          }
+          .d-lg-inline {
+            display: inline !important;
+          }
+          .d-lg-inline-block {
+            display: inline-block !important;
+          }
+          .d-lg-block {
+            display: block !important;
+          }
+          .d-lg-table {
+            display: table !important;
+          }
+          .d-lg-table-row {
+            display: table-row !important;
+          }
+          .d-lg-table-cell {
+            display: table-cell !important;
+          }
+          .d-lg-flex {
+            display: flex !important;
+          }
+          .d-lg-inline-flex {
+            display: inline-flex !important;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .d-xl-none {
+            display: none !important;
+          }
+          .d-xl-inline {
+            display: inline !important;
+          }
+          .d-xl-inline-block {
+            display: inline-block !important;
+          }
+          .d-xl-block {
+            display: block !important;
+          }
+          .d-xl-table {
+            display: table !important;
+          }
+          .d-xl-table-row {
+            display: table-row !important;
+          }
+          .d-xl-table-cell {
+            display: table-cell !important;
+          }
+          .d-xl-flex {
+            display: flex !important;
+          }
+          .d-xl-inline-flex {
+            display: inline-flex !important;
+          }
+        }
+
+        @media print {
+          .d-print-none {
+            display: none !important;
+          }
+          .d-print-inline {
+            display: inline !important;
+          }
+          .d-print-inline-block {
+            display: inline-block !important;
+          }
+          .d-print-block {
+            display: block !important;
+          }
+          .d-print-table {
+            display: table !important;
+          }
+          .d-print-table-row {
+            display: table-row !important;
+          }
+          .d-print-table-cell {
+            display: table-cell !important;
+          }
+          .d-print-flex {
+            display: flex !important;
+          }
+          .d-print-inline-flex {
+            display: inline-flex !important;
+          }
+        }
+
+        .embed-responsive {
+          position: relative;
+          display: block;
+          width: 100%;
+          padding: 0;
+          overflow: hidden;
+        }
+
+        .embed-responsive::before {
+          display: block;
+          content: "";
+        }
+
+        .embed-responsive .embed-responsive-item,
+        .embed-responsive iframe,
+        .embed-responsive embed,
+        .embed-responsive object,
+        .embed-responsive video {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+
+        .embed-responsive-21by9::before {
+          padding-top: 42.85714%;
+        }
+
+        .embed-responsive-16by9::before {
+          padding-top: 56.25%;
+        }
+
+        .embed-responsive-3by4::before {
+          padding-top: 133.33333%;
+        }
+
+        .embed-responsive-1by1::before {
+          padding-top: 100%;
+        }
+
+        .flex-row {
+          flex-direction: row !important;
+        }
+
+        .flex-column {
+          flex-direction: column !important;
+        }
+
+        .flex-row-reverse {
+          flex-direction: row-reverse !important;
+        }
+
+        .flex-column-reverse {
+          flex-direction: column-reverse !important;
+        }
+
+        .flex-wrap {
+          flex-wrap: wrap !important;
+        }
+
+        .flex-nowrap {
+          flex-wrap: nowrap !important;
+        }
+
+        .flex-wrap-reverse {
+          flex-wrap: wrap-reverse !important;
+        }
+
+        .flex-fill {
+          flex: 1 1 auto !important;
+        }
+
+        .flex-grow-0 {
+          flex-grow: 0 !important;
+        }
+
+        .flex-grow-1 {
+          flex-grow: 1 !important;
+        }
+
+        .flex-shrink-0 {
+          flex-shrink: 0 !important;
+        }
+
+        .flex-shrink-1 {
+          flex-shrink: 1 !important;
+        }
+
+        .justify-content-start {
+          justify-content: flex-start !important;
+        }
+
+        .justify-content-end {
+          justify-content: flex-end !important;
+        }
+
+        .justify-content-center {
+          justify-content: center !important;
+        }
+
+        .justify-content-between {
+          justify-content: space-between !important;
+        }
+
+        .justify-content-around {
+          justify-content: space-around !important;
+        }
+
+        .align-items-start {
+          align-items: flex-start !important;
+        }
+
+        .align-items-end {
+          align-items: flex-end !important;
+        }
+
+        .align-items-center {
+          align-items: center !important;
+        }
+
+        .align-items-baseline {
+          align-items: baseline !important;
+        }
+
+        .align-items-stretch {
+          align-items: stretch !important;
+        }
+
+        .align-content-start {
+          align-content: flex-start !important;
+        }
+
+        .align-content-end {
+          align-content: flex-end !important;
+        }
+
+        .align-content-center {
+          align-content: center !important;
+        }
+
+        .align-content-between {
+          align-content: space-between !important;
+        }
+
+        .align-content-around {
+          align-content: space-around !important;
+        }
+
+        .align-content-stretch {
+          align-content: stretch !important;
+        }
+
+        .align-self-auto {
+          align-self: auto !important;
+        }
+
+        .align-self-start {
+          align-self: flex-start !important;
+        }
+
+        .align-self-end {
+          align-self: flex-end !important;
+        }
+
+        .align-self-center {
+          align-self: center !important;
+        }
+
+        .align-self-baseline {
+          align-self: baseline !important;
+        }
+
+        .align-self-stretch {
+          align-self: stretch !important;
+        }
+
+        @media (min-width: 576px) {
+          .flex-sm-row {
+            flex-direction: row !important;
+          }
+          .flex-sm-column {
+            flex-direction: column !important;
+          }
+          .flex-sm-row-reverse {
+            flex-direction: row-reverse !important;
+          }
+          .flex-sm-column-reverse {
+            flex-direction: column-reverse !important;
+          }
+          .flex-sm-wrap {
+            flex-wrap: wrap !important;
+          }
+          .flex-sm-nowrap {
+            flex-wrap: nowrap !important;
+          }
+          .flex-sm-wrap-reverse {
+            flex-wrap: wrap-reverse !important;
+          }
+          .flex-sm-fill {
+            flex: 1 1 auto !important;
+          }
+          .flex-sm-grow-0 {
+            flex-grow: 0 !important;
+          }
+          .flex-sm-grow-1 {
+            flex-grow: 1 !important;
+          }
+          .flex-sm-shrink-0 {
+            flex-shrink: 0 !important;
+          }
+          .flex-sm-shrink-1 {
+            flex-shrink: 1 !important;
+          }
+          .justify-content-sm-start {
+            justify-content: flex-start !important;
+          }
+          .justify-content-sm-end {
+            justify-content: flex-end !important;
+          }
+          .justify-content-sm-center {
+            justify-content: center !important;
+          }
+          .justify-content-sm-between {
+            justify-content: space-between !important;
+          }
+          .justify-content-sm-around {
+            justify-content: space-around !important;
+          }
+          .align-items-sm-start {
+            align-items: flex-start !important;
+          }
+          .align-items-sm-end {
+            align-items: flex-end !important;
+          }
+          .align-items-sm-center {
+            align-items: center !important;
+          }
+          .align-items-sm-baseline {
+            align-items: baseline !important;
+          }
+          .align-items-sm-stretch {
+            align-items: stretch !important;
+          }
+          .align-content-sm-start {
+            align-content: flex-start !important;
+          }
+          .align-content-sm-end {
+            align-content: flex-end !important;
+          }
+          .align-content-sm-center {
+            align-content: center !important;
+          }
+          .align-content-sm-between {
+            align-content: space-between !important;
+          }
+          .align-content-sm-around {
+            align-content: space-around !important;
+          }
+          .align-content-sm-stretch {
+            align-content: stretch !important;
+          }
+          .align-self-sm-auto {
+            align-self: auto !important;
+          }
+          .align-self-sm-start {
+            align-self: flex-start !important;
+          }
+          .align-self-sm-end {
+            align-self: flex-end !important;
+          }
+          .align-self-sm-center {
+            align-self: center !important;
+          }
+          .align-self-sm-baseline {
+            align-self: baseline !important;
+          }
+          .align-self-sm-stretch {
+            align-self: stretch !important;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .flex-md-row {
+            flex-direction: row !important;
+          }
+          .flex-md-column {
+            flex-direction: column !important;
+          }
+          .flex-md-row-reverse {
+            flex-direction: row-reverse !important;
+          }
+          .flex-md-column-reverse {
+            flex-direction: column-reverse !important;
+          }
+          .flex-md-wrap {
+            flex-wrap: wrap !important;
+          }
+          .flex-md-nowrap {
+            flex-wrap: nowrap !important;
+          }
+          .flex-md-wrap-reverse {
+            flex-wrap: wrap-reverse !important;
+          }
+          .flex-md-fill {
+            flex: 1 1 auto !important;
+          }
+          .flex-md-grow-0 {
+            flex-grow: 0 !important;
+          }
+          .flex-md-grow-1 {
+            flex-grow: 1 !important;
+          }
+          .flex-md-shrink-0 {
+            flex-shrink: 0 !important;
+          }
+          .flex-md-shrink-1 {
+            flex-shrink: 1 !important;
+          }
+          .justify-content-md-start {
+            justify-content: flex-start !important;
+          }
+          .justify-content-md-end {
+            justify-content: flex-end !important;
+          }
+          .justify-content-md-center {
+            justify-content: center !important;
+          }
+          .justify-content-md-between {
+            justify-content: space-between !important;
+          }
+          .justify-content-md-around {
+            justify-content: space-around !important;
+          }
+          .align-items-md-start {
+            align-items: flex-start !important;
+          }
+          .align-items-md-end {
+            align-items: flex-end !important;
+          }
+          .align-items-md-center {
+            align-items: center !important;
+          }
+          .align-items-md-baseline {
+            align-items: baseline !important;
+          }
+          .align-items-md-stretch {
+            align-items: stretch !important;
+          }
+          .align-content-md-start {
+            align-content: flex-start !important;
+          }
+          .align-content-md-end {
+            align-content: flex-end !important;
+          }
+          .align-content-md-center {
+            align-content: center !important;
+          }
+          .align-content-md-between {
+            align-content: space-between !important;
+          }
+          .align-content-md-around {
+            align-content: space-around !important;
+          }
+          .align-content-md-stretch {
+            align-content: stretch !important;
+          }
+          .align-self-md-auto {
+            align-self: auto !important;
+          }
+          .align-self-md-start {
+            align-self: flex-start !important;
+          }
+          .align-self-md-end {
+            align-self: flex-end !important;
+          }
+          .align-self-md-center {
+            align-self: center !important;
+          }
+          .align-self-md-baseline {
+            align-self: baseline !important;
+          }
+          .align-self-md-stretch {
+            align-self: stretch !important;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .flex-lg-row {
+            flex-direction: row !important;
+          }
+          .flex-lg-column {
+            flex-direction: column !important;
+          }
+          .flex-lg-row-reverse {
+            flex-direction: row-reverse !important;
+          }
+          .flex-lg-column-reverse {
+            flex-direction: column-reverse !important;
+          }
+          .flex-lg-wrap {
+            flex-wrap: wrap !important;
+          }
+          .flex-lg-nowrap {
+            flex-wrap: nowrap !important;
+          }
+          .flex-lg-wrap-reverse {
+            flex-wrap: wrap-reverse !important;
+          }
+          .flex-lg-fill {
+            flex: 1 1 auto !important;
+          }
+          .flex-lg-grow-0 {
+            flex-grow: 0 !important;
+          }
+          .flex-lg-grow-1 {
+            flex-grow: 1 !important;
+          }
+          .flex-lg-shrink-0 {
+            flex-shrink: 0 !important;
+          }
+          .flex-lg-shrink-1 {
+            flex-shrink: 1 !important;
+          }
+          .justify-content-lg-start {
+            justify-content: flex-start !important;
+          }
+          .justify-content-lg-end {
+            justify-content: flex-end !important;
+          }
+          .justify-content-lg-center {
+            justify-content: center !important;
+          }
+          .justify-content-lg-between {
+            justify-content: space-between !important;
+          }
+          .justify-content-lg-around {
+            justify-content: space-around !important;
+          }
+          .align-items-lg-start {
+            align-items: flex-start !important;
+          }
+          .align-items-lg-end {
+            align-items: flex-end !important;
+          }
+          .align-items-lg-center {
+            align-items: center !important;
+          }
+          .align-items-lg-baseline {
+            align-items: baseline !important;
+          }
+          .align-items-lg-stretch {
+            align-items: stretch !important;
+          }
+          .align-content-lg-start {
+            align-content: flex-start !important;
+          }
+          .align-content-lg-end {
+            align-content: flex-end !important;
+          }
+          .align-content-lg-center {
+            align-content: center !important;
+          }
+          .align-content-lg-between {
+            align-content: space-between !important;
+          }
+          .align-content-lg-around {
+            align-content: space-around !important;
+          }
+          .align-content-lg-stretch {
+            align-content: stretch !important;
+          }
+          .align-self-lg-auto {
+            align-self: auto !important;
+          }
+          .align-self-lg-start {
+            align-self: flex-start !important;
+          }
+          .align-self-lg-end {
+            align-self: flex-end !important;
+          }
+          .align-self-lg-center {
+            align-self: center !important;
+          }
+          .align-self-lg-baseline {
+            align-self: baseline !important;
+          }
+          .align-self-lg-stretch {
+            align-self: stretch !important;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .flex-xl-row {
+            flex-direction: row !important;
+          }
+          .flex-xl-column {
+            flex-direction: column !important;
+          }
+          .flex-xl-row-reverse {
+            flex-direction: row-reverse !important;
+          }
+          .flex-xl-column-reverse {
+            flex-direction: column-reverse !important;
+          }
+          .flex-xl-wrap {
+            flex-wrap: wrap !important;
+          }
+          .flex-xl-nowrap {
+            flex-wrap: nowrap !important;
+          }
+          .flex-xl-wrap-reverse {
+            flex-wrap: wrap-reverse !important;
+          }
+          .flex-xl-fill {
+            flex: 1 1 auto !important;
+          }
+          .flex-xl-grow-0 {
+            flex-grow: 0 !important;
+          }
+          .flex-xl-grow-1 {
+            flex-grow: 1 !important;
+          }
+          .flex-xl-shrink-0 {
+            flex-shrink: 0 !important;
+          }
+          .flex-xl-shrink-1 {
+            flex-shrink: 1 !important;
+          }
+          .justify-content-xl-start {
+            justify-content: flex-start !important;
+          }
+          .justify-content-xl-end {
+            justify-content: flex-end !important;
+          }
+          .justify-content-xl-center {
+            justify-content: center !important;
+          }
+          .justify-content-xl-between {
+            justify-content: space-between !important;
+          }
+          .justify-content-xl-around {
+            justify-content: space-around !important;
+          }
+          .align-items-xl-start {
+            align-items: flex-start !important;
+          }
+          .align-items-xl-end {
+            align-items: flex-end !important;
+          }
+          .align-items-xl-center {
+            align-items: center !important;
+          }
+          .align-items-xl-baseline {
+            align-items: baseline !important;
+          }
+          .align-items-xl-stretch {
+            align-items: stretch !important;
+          }
+          .align-content-xl-start {
+            align-content: flex-start !important;
+          }
+          .align-content-xl-end {
+            align-content: flex-end !important;
+          }
+          .align-content-xl-center {
+            align-content: center !important;
+          }
+          .align-content-xl-between {
+            align-content: space-between !important;
+          }
+          .align-content-xl-around {
+            align-content: space-around !important;
+          }
+          .align-content-xl-stretch {
+            align-content: stretch !important;
+          }
+          .align-self-xl-auto {
+            align-self: auto !important;
+          }
+          .align-self-xl-start {
+            align-self: flex-start !important;
+          }
+          .align-self-xl-end {
+            align-self: flex-end !important;
+          }
+          .align-self-xl-center {
+            align-self: center !important;
+          }
+          .align-self-xl-baseline {
+            align-self: baseline !important;
+          }
+          .align-self-xl-stretch {
+            align-self: stretch !important;
+          }
+        }
+
+        .float-left {
+          float: left !important;
+        }
+
+        .float-right {
+          float: right !important;
+        }
+
+        .float-none {
+          float: none !important;
+        }
+
+        @media (min-width: 576px) {
+          .float-sm-left {
+            float: left !important;
+          }
+          .float-sm-right {
+            float: right !important;
+          }
+          .float-sm-none {
+            float: none !important;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .float-md-left {
+            float: left !important;
+          }
+          .float-md-right {
+            float: right !important;
+          }
+          .float-md-none {
+            float: none !important;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .float-lg-left {
+            float: left !important;
+          }
+          .float-lg-right {
+            float: right !important;
+          }
+          .float-lg-none {
+            float: none !important;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .float-xl-left {
+            float: left !important;
+          }
+          .float-xl-right {
+            float: right !important;
+          }
+          .float-xl-none {
+            float: none !important;
+          }
+        }
+
+        .overflow-auto {
+          overflow: auto !important;
+        }
+
+        .overflow-hidden {
+          overflow: hidden !important;
+        }
+
+        .position-static {
+          position: static !important;
+        }
+
+        .position-relative {
+          position: relative !important;
+        }
+
+        .position-absolute {
+          position: absolute !important;
+        }
+
+        .position-fixed {
+          position: fixed !important;
+        }
+
+        .position-sticky {
+          position: -webkit-sticky !important;
+          position: sticky !important;
+        }
+
+        .fixed-top {
+          position: fixed;
+          top: 0;
+          right: 0;
+          left: 0;
+          z-index: 1030;
+        }
+
+        .fixed-bottom {
+          position: fixed;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          z-index: 1030;
+        }
+
+        @supports ((position: -webkit-sticky) or (position: sticky)) {
+          .sticky-top {
+            position: -webkit-sticky;
+            position: sticky;
+            top: 0;
+            z-index: 1020;
+          }
+        }
+
+        .sr-only {
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
+        }
+
+        .sr-only-focusable:active,
+        .sr-only-focusable:focus {
+          position: static;
+          width: auto;
+          height: auto;
+          overflow: visible;
+          clip: auto;
+          white-space: normal;
+        }
+
+        .shadow-sm {
+          box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;
+        }
+
+        .shadow {
+          box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
+        }
+
+        .shadow-lg {
+          box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175) !important;
+        }
+
+        .shadow-none {
+          box-shadow: none !important;
+        }
+
+        .w-25 {
+          width: 25% !important;
+        }
+
+        .w-50 {
+          width: 50% !important;
+        }
+
+        .w-75 {
+          width: 75% !important;
+        }
+
+        .w-100 {
+          width: 100% !important;
+        }
+
+        .w-auto {
+          width: auto !important;
+        }
+
+        .h-25 {
+          height: 25% !important;
+        }
+
+        .h-50 {
+          height: 50% !important;
+        }
+
+        .h-75 {
+          height: 75% !important;
+        }
+
+        .h-100 {
+          height: 100% !important;
+        }
+
+        .h-auto {
+          height: auto !important;
+        }
+
+        .mw-100 {
+          max-width: 100% !important;
+        }
+
+        .mh-100 {
+          max-height: 100% !important;
+        }
+
+        .min-vw-100 {
+          min-width: 100vw !important;
+        }
+
+        .min-vh-100 {
+          min-height: 100vh !important;
+        }
+
+        .vw-100 {
+          width: 100vw !important;
+        }
+
+        .vh-100 {
+          height: 100vh !important;
+        }
+
+        .m-0 {
+          margin: 0 !important;
+        }
+
+        .mt-0,
+        .my-0 {
+          margin-top: 0 !important;
+        }
+
+        .mr-0,
+        .mx-0 {
+          margin-right: 0 !important;
+        }
+
+        .mb-0,
+        .my-0 {
+          margin-bottom: 0 !important;
+        }
+
+        .ml-0,
+        .mx-0 {
+          margin-left: 0 !important;
+        }
+
+        .m-1 {
+          margin: 0.25rem !important;
+        }
+
+        .mt-1,
+        .my-1 {
+          margin-top: 0.25rem !important;
+        }
+
+        .mr-1,
+        .mx-1 {
+          margin-right: 0.25rem !important;
+        }
+
+        .mb-1,
+        .my-1 {
+          margin-bottom: 0.25rem !important;
+        }
+
+        .ml-1,
+        .mx-1 {
+          margin-left: 0.25rem !important;
+        }
+
+        .m-2 {
+          margin: 0.5rem !important;
+        }
+
+        .mt-2,
+        .my-2 {
+          margin-top: 0.5rem !important;
+        }
+
+        .mr-2,
+        .mx-2 {
+          margin-right: 0.5rem !important;
+        }
+
+        .mb-2,
+        .my-2 {
+          margin-bottom: 0.5rem !important;
+        }
+
+        .ml-2,
+        .mx-2 {
+          margin-left: 0.5rem !important;
+        }
+
+        .m-3 {
+          margin: 1rem !important;
+        }
+
+        .mt-3,
+        .my-3 {
+          margin-top: 1rem !important;
+        }
+
+        .mr-3,
+        .mx-3 {
+          margin-right: 1rem !important;
+        }
+
+        .mb-3,
+        .my-3 {
+          margin-bottom: 1rem !important;
+        }
+
+        .ml-3,
+        .mx-3 {
+          margin-left: 1rem !important;
+        }
+
+        .m-4 {
+          margin: 1.5rem !important;
+        }
+
+        .mt-4,
+        .my-4 {
+          margin-top: 1.5rem !important;
+        }
+
+        .mr-4,
+        .mx-4 {
+          margin-right: 1.5rem !important;
+        }
+
+        .mb-4,
+        .my-4 {
+          margin-bottom: 1.5rem !important;
+        }
+
+        .ml-4,
+        .mx-4 {
+          margin-left: 1.5rem !important;
+        }
+
+        .m-5 {
+          margin: 3rem !important;
+        }
+
+        .mt-5,
+        .my-5 {
+          margin-top: 3rem !important;
+        }
+
+        .mr-5,
+        .mx-5 {
+          margin-right: 3rem !important;
+        }
+
+        .mb-5,
+        .my-5 {
+          margin-bottom: 3rem !important;
+        }
+
+        .ml-5,
+        .mx-5 {
+          margin-left: 3rem !important;
+        }
+
+        .p-0 {
+          padding: 0 !important;
+        }
+
+        .pt-0,
+        .py-0 {
+          padding-top: 0 !important;
+        }
+
+        .pr-0,
+        .px-0 {
+          padding-right: 0 !important;
+        }
+
+        .pb-0,
+        .py-0 {
+          padding-bottom: 0 !important;
+        }
+
+        .pl-0,
+        .px-0 {
+          padding-left: 0 !important;
+        }
+
+        .p-1 {
+          padding: 0.25rem !important;
+        }
+
+        .pt-1,
+        .py-1 {
+          padding-top: 0.25rem !important;
+        }
+
+        .pr-1,
+        .px-1 {
+          padding-right: 0.25rem !important;
+        }
+
+        .pb-1,
+        .py-1 {
+          padding-bottom: 0.25rem !important;
+        }
+
+        .pl-1,
+        .px-1 {
+          padding-left: 0.25rem !important;
+        }
+
+        .p-2 {
+          padding: 0.5rem !important;
+        }
+
+        .pt-2,
+        .py-2 {
+          padding-top: 0.5rem !important;
+        }
+
+        .pr-2,
+        .px-2 {
+          padding-right: 0.5rem !important;
+        }
+
+        .pb-2,
+        .py-2 {
+          padding-bottom: 0.5rem !important;
+        }
+
+        .pl-2,
+        .px-2 {
+          padding-left: 0.5rem !important;
+        }
+
+        .p-3 {
+          padding: 1rem !important;
+        }
+
+        .pt-3,
+        .py-3 {
+          padding-top: 1rem !important;
+        }
+
+        .pr-3,
+        .px-3 {
+          padding-right: 1rem !important;
+        }
+
+        .pb-3,
+        .py-3 {
+          padding-bottom: 1rem !important;
+        }
+
+        .pl-3,
+        .px-3 {
+          padding-left: 1rem !important;
+        }
+
+        .p-4 {
+          padding: 1.5rem !important;
+        }
+
+        .pt-4,
+        .py-4 {
+          padding-top: 1.5rem !important;
+        }
+
+        .pr-4,
+        .px-4 {
+          padding-right: 1.5rem !important;
+        }
+
+        .pb-4,
+        .py-4 {
+          padding-bottom: 1.5rem !important;
+        }
+
+        .pl-4,
+        .px-4 {
+          padding-left: 1.5rem !important;
+        }
+
+        .p-5 {
+          padding: 3rem !important;
+        }
+
+        .pt-5,
+        .py-5 {
+          padding-top: 3rem !important;
+        }
+
+        .pr-5,
+        .px-5 {
+          padding-right: 3rem !important;
+        }
+
+        .pb-5,
+        .py-5 {
+          padding-bottom: 3rem !important;
+        }
+
+        .pl-5,
+        .px-5 {
+          padding-left: 3rem !important;
+        }
+
+        .m-n1 {
+          margin: -0.25rem !important;
+        }
+
+        .mt-n1,
+        .my-n1 {
+          margin-top: -0.25rem !important;
+        }
+
+        .mr-n1,
+        .mx-n1 {
+          margin-right: -0.25rem !important;
+        }
+
+        .mb-n1,
+        .my-n1 {
+          margin-bottom: -0.25rem !important;
+        }
+
+        .ml-n1,
+        .mx-n1 {
+          margin-left: -0.25rem !important;
+        }
+
+        .m-n2 {
+          margin: -0.5rem !important;
+        }
+
+        .mt-n2,
+        .my-n2 {
+          margin-top: -0.5rem !important;
+        }
+
+        .mr-n2,
+        .mx-n2 {
+          margin-right: -0.5rem !important;
+        }
+
+        .mb-n2,
+        .my-n2 {
+          margin-bottom: -0.5rem !important;
+        }
+
+        .ml-n2,
+        .mx-n2 {
+          margin-left: -0.5rem !important;
+        }
+
+        .m-n3 {
+          margin: -1rem !important;
+        }
+
+        .mt-n3,
+        .my-n3 {
+          margin-top: -1rem !important;
+        }
+
+        .mr-n3,
+        .mx-n3 {
+          margin-right: -1rem !important;
+        }
+
+        .mb-n3,
+        .my-n3 {
+          margin-bottom: -1rem !important;
+        }
+
+        .ml-n3,
+        .mx-n3 {
+          margin-left: -1rem !important;
+        }
+
+        .m-n4 {
+          margin: -1.5rem !important;
+        }
+
+        .mt-n4,
+        .my-n4 {
+          margin-top: -1.5rem !important;
+        }
+
+        .mr-n4,
+        .mx-n4 {
+          margin-right: -1.5rem !important;
+        }
+
+        .mb-n4,
+        .my-n4 {
+          margin-bottom: -1.5rem !important;
+        }
+
+        .ml-n4,
+        .mx-n4 {
+          margin-left: -1.5rem !important;
+        }
+
+        .m-n5 {
+          margin: -3rem !important;
+        }
+
+        .mt-n5,
+        .my-n5 {
+          margin-top: -3rem !important;
+        }
+
+        .mr-n5,
+        .mx-n5 {
+          margin-right: -3rem !important;
+        }
+
+        .mb-n5,
+        .my-n5 {
+          margin-bottom: -3rem !important;
+        }
+
+        .ml-n5,
+        .mx-n5 {
+          margin-left: -3rem !important;
+        }
+
+        .m-auto {
+          margin: auto !important;
+        }
+
+        .mt-auto,
+        .my-auto {
+          margin-top: auto !important;
+        }
+
+        .mr-auto,
+        .mx-auto {
+          margin-right: auto !important;
+        }
+
+        .mb-auto,
+        .my-auto {
+          margin-bottom: auto !important;
+        }
+
+        .ml-auto,
+        .mx-auto {
+          margin-left: auto !important;
+        }
+
+        @media (min-width: 576px) {
+          .m-sm-0 {
+            margin: 0 !important;
+          }
+          .mt-sm-0,
+          .my-sm-0 {
+            margin-top: 0 !important;
+          }
+          .mr-sm-0,
+          .mx-sm-0 {
+            margin-right: 0 !important;
+          }
+          .mb-sm-0,
+          .my-sm-0 {
+            margin-bottom: 0 !important;
+          }
+          .ml-sm-0,
+          .mx-sm-0 {
+            margin-left: 0 !important;
+          }
+          .m-sm-1 {
+            margin: 0.25rem !important;
+          }
+          .mt-sm-1,
+          .my-sm-1 {
+            margin-top: 0.25rem !important;
+          }
+          .mr-sm-1,
+          .mx-sm-1 {
+            margin-right: 0.25rem !important;
+          }
+          .mb-sm-1,
+          .my-sm-1 {
+            margin-bottom: 0.25rem !important;
+          }
+          .ml-sm-1,
+          .mx-sm-1 {
+            margin-left: 0.25rem !important;
+          }
+          .m-sm-2 {
+            margin: 0.5rem !important;
+          }
+          .mt-sm-2,
+          .my-sm-2 {
+            margin-top: 0.5rem !important;
+          }
+          .mr-sm-2,
+          .mx-sm-2 {
+            margin-right: 0.5rem !important;
+          }
+          .mb-sm-2,
+          .my-sm-2 {
+            margin-bottom: 0.5rem !important;
+          }
+          .ml-sm-2,
+          .mx-sm-2 {
+            margin-left: 0.5rem !important;
+          }
+          .m-sm-3 {
+            margin: 1rem !important;
+          }
+          .mt-sm-3,
+          .my-sm-3 {
+            margin-top: 1rem !important;
+          }
+          .mr-sm-3,
+          .mx-sm-3 {
+            margin-right: 1rem !important;
+          }
+          .mb-sm-3,
+          .my-sm-3 {
+            margin-bottom: 1rem !important;
+          }
+          .ml-sm-3,
+          .mx-sm-3 {
+            margin-left: 1rem !important;
+          }
+          .m-sm-4 {
+            margin: 1.5rem !important;
+          }
+          .mt-sm-4,
+          .my-sm-4 {
+            margin-top: 1.5rem !important;
+          }
+          .mr-sm-4,
+          .mx-sm-4 {
+            margin-right: 1.5rem !important;
+          }
+          .mb-sm-4,
+          .my-sm-4 {
+            margin-bottom: 1.5rem !important;
+          }
+          .ml-sm-4,
+          .mx-sm-4 {
+            margin-left: 1.5rem !important;
+          }
+          .m-sm-5 {
+            margin: 3rem !important;
+          }
+          .mt-sm-5,
+          .my-sm-5 {
+            margin-top: 3rem !important;
+          }
+          .mr-sm-5,
+          .mx-sm-5 {
+            margin-right: 3rem !important;
+          }
+          .mb-sm-5,
+          .my-sm-5 {
+            margin-bottom: 3rem !important;
+          }
+          .ml-sm-5,
+          .mx-sm-5 {
+            margin-left: 3rem !important;
+          }
+          .p-sm-0 {
+            padding: 0 !important;
+          }
+          .pt-sm-0,
+          .py-sm-0 {
+            padding-top: 0 !important;
+          }
+          .pr-sm-0,
+          .px-sm-0 {
+            padding-right: 0 !important;
+          }
+          .pb-sm-0,
+          .py-sm-0 {
+            padding-bottom: 0 !important;
+          }
+          .pl-sm-0,
+          .px-sm-0 {
+            padding-left: 0 !important;
+          }
+          .p-sm-1 {
+            padding: 0.25rem !important;
+          }
+          .pt-sm-1,
+          .py-sm-1 {
+            padding-top: 0.25rem !important;
+          }
+          .pr-sm-1,
+          .px-sm-1 {
+            padding-right: 0.25rem !important;
+          }
+          .pb-sm-1,
+          .py-sm-1 {
+            padding-bottom: 0.25rem !important;
+          }
+          .pl-sm-1,
+          .px-sm-1 {
+            padding-left: 0.25rem !important;
+          }
+          .p-sm-2 {
+            padding: 0.5rem !important;
+          }
+          .pt-sm-2,
+          .py-sm-2 {
+            padding-top: 0.5rem !important;
+          }
+          .pr-sm-2,
+          .px-sm-2 {
+            padding-right: 0.5rem !important;
+          }
+          .pb-sm-2,
+          .py-sm-2 {
+            padding-bottom: 0.5rem !important;
+          }
+          .pl-sm-2,
+          .px-sm-2 {
+            padding-left: 0.5rem !important;
+          }
+          .p-sm-3 {
+            padding: 1rem !important;
+          }
+          .pt-sm-3,
+          .py-sm-3 {
+            padding-top: 1rem !important;
+          }
+          .pr-sm-3,
+          .px-sm-3 {
+            padding-right: 1rem !important;
+          }
+          .pb-sm-3,
+          .py-sm-3 {
+            padding-bottom: 1rem !important;
+          }
+          .pl-sm-3,
+          .px-sm-3 {
+            padding-left: 1rem !important;
+          }
+          .p-sm-4 {
+            padding: 1.5rem !important;
+          }
+          .pt-sm-4,
+          .py-sm-4 {
+            padding-top: 1.5rem !important;
+          }
+          .pr-sm-4,
+          .px-sm-4 {
+            padding-right: 1.5rem !important;
+          }
+          .pb-sm-4,
+          .py-sm-4 {
+            padding-bottom: 1.5rem !important;
+          }
+          .pl-sm-4,
+          .px-sm-4 {
+            padding-left: 1.5rem !important;
+          }
+          .p-sm-5 {
+            padding: 3rem !important;
+          }
+          .pt-sm-5,
+          .py-sm-5 {
+            padding-top: 3rem !important;
+          }
+          .pr-sm-5,
+          .px-sm-5 {
+            padding-right: 3rem !important;
+          }
+          .pb-sm-5,
+          .py-sm-5 {
+            padding-bottom: 3rem !important;
+          }
+          .pl-sm-5,
+          .px-sm-5 {
+            padding-left: 3rem !important;
+          }
+          .m-sm-n1 {
+            margin: -0.25rem !important;
+          }
+          .mt-sm-n1,
+          .my-sm-n1 {
+            margin-top: -0.25rem !important;
+          }
+          .mr-sm-n1,
+          .mx-sm-n1 {
+            margin-right: -0.25rem !important;
+          }
+          .mb-sm-n1,
+          .my-sm-n1 {
+            margin-bottom: -0.25rem !important;
+          }
+          .ml-sm-n1,
+          .mx-sm-n1 {
+            margin-left: -0.25rem !important;
+          }
+          .m-sm-n2 {
+            margin: -0.5rem !important;
+          }
+          .mt-sm-n2,
+          .my-sm-n2 {
+            margin-top: -0.5rem !important;
+          }
+          .mr-sm-n2,
+          .mx-sm-n2 {
+            margin-right: -0.5rem !important;
+          }
+          .mb-sm-n2,
+          .my-sm-n2 {
+            margin-bottom: -0.5rem !important;
+          }
+          .ml-sm-n2,
+          .mx-sm-n2 {
+            margin-left: -0.5rem !important;
+          }
+          .m-sm-n3 {
+            margin: -1rem !important;
+          }
+          .mt-sm-n3,
+          .my-sm-n3 {
+            margin-top: -1rem !important;
+          }
+          .mr-sm-n3,
+          .mx-sm-n3 {
+            margin-right: -1rem !important;
+          }
+          .mb-sm-n3,
+          .my-sm-n3 {
+            margin-bottom: -1rem !important;
+          }
+          .ml-sm-n3,
+          .mx-sm-n3 {
+            margin-left: -1rem !important;
+          }
+          .m-sm-n4 {
+            margin: -1.5rem !important;
+          }
+          .mt-sm-n4,
+          .my-sm-n4 {
+            margin-top: -1.5rem !important;
+          }
+          .mr-sm-n4,
+          .mx-sm-n4 {
+            margin-right: -1.5rem !important;
+          }
+          .mb-sm-n4,
+          .my-sm-n4 {
+            margin-bottom: -1.5rem !important;
+          }
+          .ml-sm-n4,
+          .mx-sm-n4 {
+            margin-left: -1.5rem !important;
+          }
+          .m-sm-n5 {
+            margin: -3rem !important;
+          }
+          .mt-sm-n5,
+          .my-sm-n5 {
+            margin-top: -3rem !important;
+          }
+          .mr-sm-n5,
+          .mx-sm-n5 {
+            margin-right: -3rem !important;
+          }
+          .mb-sm-n5,
+          .my-sm-n5 {
+            margin-bottom: -3rem !important;
+          }
+          .ml-sm-n5,
+          .mx-sm-n5 {
+            margin-left: -3rem !important;
+          }
+          .m-sm-auto {
+            margin: auto !important;
+          }
+          .mt-sm-auto,
+          .my-sm-auto {
+            margin-top: auto !important;
+          }
+          .mr-sm-auto,
+          .mx-sm-auto {
+            margin-right: auto !important;
+          }
+          .mb-sm-auto,
+          .my-sm-auto {
+            margin-bottom: auto !important;
+          }
+          .ml-sm-auto,
+          .mx-sm-auto {
+            margin-left: auto !important;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .m-md-0 {
+            margin: 0 !important;
+          }
+          .mt-md-0,
+          .my-md-0 {
+            margin-top: 0 !important;
+          }
+          .mr-md-0,
+          .mx-md-0 {
+            margin-right: 0 !important;
+          }
+          .mb-md-0,
+          .my-md-0 {
+            margin-bottom: 0 !important;
+          }
+          .ml-md-0,
+          .mx-md-0 {
+            margin-left: 0 !important;
+          }
+          .m-md-1 {
+            margin: 0.25rem !important;
+          }
+          .mt-md-1,
+          .my-md-1 {
+            margin-top: 0.25rem !important;
+          }
+          .mr-md-1,
+          .mx-md-1 {
+            margin-right: 0.25rem !important;
+          }
+          .mb-md-1,
+          .my-md-1 {
+            margin-bottom: 0.25rem !important;
+          }
+          .ml-md-1,
+          .mx-md-1 {
+            margin-left: 0.25rem !important;
+          }
+          .m-md-2 {
+            margin: 0.5rem !important;
+          }
+          .mt-md-2,
+          .my-md-2 {
+            margin-top: 0.5rem !important;
+          }
+          .mr-md-2,
+          .mx-md-2 {
+            margin-right: 0.5rem !important;
+          }
+          .mb-md-2,
+          .my-md-2 {
+            margin-bottom: 0.5rem !important;
+          }
+          .ml-md-2,
+          .mx-md-2 {
+            margin-left: 0.5rem !important;
+          }
+          .m-md-3 {
+            margin: 1rem !important;
+          }
+          .mt-md-3,
+          .my-md-3 {
+            margin-top: 1rem !important;
+          }
+          .mr-md-3,
+          .mx-md-3 {
+            margin-right: 1rem !important;
+          }
+          .mb-md-3,
+          .my-md-3 {
+            margin-bottom: 1rem !important;
+          }
+          .ml-md-3,
+          .mx-md-3 {
+            margin-left: 1rem !important;
+          }
+          .m-md-4 {
+            margin: 1.5rem !important;
+          }
+          .mt-md-4,
+          .my-md-4 {
+            margin-top: 1.5rem !important;
+          }
+          .mr-md-4,
+          .mx-md-4 {
+            margin-right: 1.5rem !important;
+          }
+          .mb-md-4,
+          .my-md-4 {
+            margin-bottom: 1.5rem !important;
+          }
+          .ml-md-4,
+          .mx-md-4 {
+            margin-left: 1.5rem !important;
+          }
+          .m-md-5 {
+            margin: 3rem !important;
+          }
+          .mt-md-5,
+          .my-md-5 {
+            margin-top: 3rem !important;
+          }
+          .mr-md-5,
+          .mx-md-5 {
+            margin-right: 3rem !important;
+          }
+          .mb-md-5,
+          .my-md-5 {
+            margin-bottom: 3rem !important;
+          }
+          .ml-md-5,
+          .mx-md-5 {
+            margin-left: 3rem !important;
+          }
+          .p-md-0 {
+            padding: 0 !important;
+          }
+          .pt-md-0,
+          .py-md-0 {
+            padding-top: 0 !important;
+          }
+          .pr-md-0,
+          .px-md-0 {
+            padding-right: 0 !important;
+          }
+          .pb-md-0,
+          .py-md-0 {
+            padding-bottom: 0 !important;
+          }
+          .pl-md-0,
+          .px-md-0 {
+            padding-left: 0 !important;
+          }
+          .p-md-1 {
+            padding: 0.25rem !important;
+          }
+          .pt-md-1,
+          .py-md-1 {
+            padding-top: 0.25rem !important;
+          }
+          .pr-md-1,
+          .px-md-1 {
+            padding-right: 0.25rem !important;
+          }
+          .pb-md-1,
+          .py-md-1 {
+            padding-bottom: 0.25rem !important;
+          }
+          .pl-md-1,
+          .px-md-1 {
+            padding-left: 0.25rem !important;
+          }
+          .p-md-2 {
+            padding: 0.5rem !important;
+          }
+          .pt-md-2,
+          .py-md-2 {
+            padding-top: 0.5rem !important;
+          }
+          .pr-md-2,
+          .px-md-2 {
+            padding-right: 0.5rem !important;
+          }
+          .pb-md-2,
+          .py-md-2 {
+            padding-bottom: 0.5rem !important;
+          }
+          .pl-md-2,
+          .px-md-2 {
+            padding-left: 0.5rem !important;
+          }
+          .p-md-3 {
+            padding: 1rem !important;
+          }
+          .pt-md-3,
+          .py-md-3 {
+            padding-top: 1rem !important;
+          }
+          .pr-md-3,
+          .px-md-3 {
+            padding-right: 1rem !important;
+          }
+          .pb-md-3,
+          .py-md-3 {
+            padding-bottom: 1rem !important;
+          }
+          .pl-md-3,
+          .px-md-3 {
+            padding-left: 1rem !important;
+          }
+          .p-md-4 {
+            padding: 1.5rem !important;
+          }
+          .pt-md-4,
+          .py-md-4 {
+            padding-top: 1.5rem !important;
+          }
+          .pr-md-4,
+          .px-md-4 {
+            padding-right: 1.5rem !important;
+          }
+          .pb-md-4,
+          .py-md-4 {
+            padding-bottom: 1.5rem !important;
+          }
+          .pl-md-4,
+          .px-md-4 {
+            padding-left: 1.5rem !important;
+          }
+          .p-md-5 {
+            padding: 3rem !important;
+          }
+          .pt-md-5,
+          .py-md-5 {
+            padding-top: 3rem !important;
+          }
+          .pr-md-5,
+          .px-md-5 {
+            padding-right: 3rem !important;
+          }
+          .pb-md-5,
+          .py-md-5 {
+            padding-bottom: 3rem !important;
+          }
+          .pl-md-5,
+          .px-md-5 {
+            padding-left: 3rem !important;
+          }
+          .m-md-n1 {
+            margin: -0.25rem !important;
+          }
+          .mt-md-n1,
+          .my-md-n1 {
+            margin-top: -0.25rem !important;
+          }
+          .mr-md-n1,
+          .mx-md-n1 {
+            margin-right: -0.25rem !important;
+          }
+          .mb-md-n1,
+          .my-md-n1 {
+            margin-bottom: -0.25rem !important;
+          }
+          .ml-md-n1,
+          .mx-md-n1 {
+            margin-left: -0.25rem !important;
+          }
+          .m-md-n2 {
+            margin: -0.5rem !important;
+          }
+          .mt-md-n2,
+          .my-md-n2 {
+            margin-top: -0.5rem !important;
+          }
+          .mr-md-n2,
+          .mx-md-n2 {
+            margin-right: -0.5rem !important;
+          }
+          .mb-md-n2,
+          .my-md-n2 {
+            margin-bottom: -0.5rem !important;
+          }
+          .ml-md-n2,
+          .mx-md-n2 {
+            margin-left: -0.5rem !important;
+          }
+          .m-md-n3 {
+            margin: -1rem !important;
+          }
+          .mt-md-n3,
+          .my-md-n3 {
+            margin-top: -1rem !important;
+          }
+          .mr-md-n3,
+          .mx-md-n3 {
+            margin-right: -1rem !important;
+          }
+          .mb-md-n3,
+          .my-md-n3 {
+            margin-bottom: -1rem !important;
+          }
+          .ml-md-n3,
+          .mx-md-n3 {
+            margin-left: -1rem !important;
+          }
+          .m-md-n4 {
+            margin: -1.5rem !important;
+          }
+          .mt-md-n4,
+          .my-md-n4 {
+            margin-top: -1.5rem !important;
+          }
+          .mr-md-n4,
+          .mx-md-n4 {
+            margin-right: -1.5rem !important;
+          }
+          .mb-md-n4,
+          .my-md-n4 {
+            margin-bottom: -1.5rem !important;
+          }
+          .ml-md-n4,
+          .mx-md-n4 {
+            margin-left: -1.5rem !important;
+          }
+          .m-md-n5 {
+            margin: -3rem !important;
+          }
+          .mt-md-n5,
+          .my-md-n5 {
+            margin-top: -3rem !important;
+          }
+          .mr-md-n5,
+          .mx-md-n5 {
+            margin-right: -3rem !important;
+          }
+          .mb-md-n5,
+          .my-md-n5 {
+            margin-bottom: -3rem !important;
+          }
+          .ml-md-n5,
+          .mx-md-n5 {
+            margin-left: -3rem !important;
+          }
+          .m-md-auto {
+            margin: auto !important;
+          }
+          .mt-md-auto,
+          .my-md-auto {
+            margin-top: auto !important;
+          }
+          .mr-md-auto,
+          .mx-md-auto {
+            margin-right: auto !important;
+          }
+          .mb-md-auto,
+          .my-md-auto {
+            margin-bottom: auto !important;
+          }
+          .ml-md-auto,
+          .mx-md-auto {
+            margin-left: auto !important;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .m-lg-0 {
+            margin: 0 !important;
+          }
+          .mt-lg-0,
+          .my-lg-0 {
+            margin-top: 0 !important;
+          }
+          .mr-lg-0,
+          .mx-lg-0 {
+            margin-right: 0 !important;
+          }
+          .mb-lg-0,
+          .my-lg-0 {
+            margin-bottom: 0 !important;
+          }
+          .ml-lg-0,
+          .mx-lg-0 {
+            margin-left: 0 !important;
+          }
+          .m-lg-1 {
+            margin: 0.25rem !important;
+          }
+          .mt-lg-1,
+          .my-lg-1 {
+            margin-top: 0.25rem !important;
+          }
+          .mr-lg-1,
+          .mx-lg-1 {
+            margin-right: 0.25rem !important;
+          }
+          .mb-lg-1,
+          .my-lg-1 {
+            margin-bottom: 0.25rem !important;
+          }
+          .ml-lg-1,
+          .mx-lg-1 {
+            margin-left: 0.25rem !important;
+          }
+          .m-lg-2 {
+            margin: 0.5rem !important;
+          }
+          .mt-lg-2,
+          .my-lg-2 {
+            margin-top: 0.5rem !important;
+          }
+          .mr-lg-2,
+          .mx-lg-2 {
+            margin-right: 0.5rem !important;
+          }
+          .mb-lg-2,
+          .my-lg-2 {
+            margin-bottom: 0.5rem !important;
+          }
+          .ml-lg-2,
+          .mx-lg-2 {
+            margin-left: 0.5rem !important;
+          }
+          .m-lg-3 {
+            margin: 1rem !important;
+          }
+          .mt-lg-3,
+          .my-lg-3 {
+            margin-top: 1rem !important;
+          }
+          .mr-lg-3,
+          .mx-lg-3 {
+            margin-right: 1rem !important;
+          }
+          .mb-lg-3,
+          .my-lg-3 {
+            margin-bottom: 1rem !important;
+          }
+          .ml-lg-3,
+          .mx-lg-3 {
+            margin-left: 1rem !important;
+          }
+          .m-lg-4 {
+            margin: 1.5rem !important;
+          }
+          .mt-lg-4,
+          .my-lg-4 {
+            margin-top: 1.5rem !important;
+          }
+          .mr-lg-4,
+          .mx-lg-4 {
+            margin-right: 1.5rem !important;
+          }
+          .mb-lg-4,
+          .my-lg-4 {
+            margin-bottom: 1.5rem !important;
+          }
+          .ml-lg-4,
+          .mx-lg-4 {
+            margin-left: 1.5rem !important;
+          }
+          .m-lg-5 {
+            margin: 3rem !important;
+          }
+          .mt-lg-5,
+          .my-lg-5 {
+            margin-top: 3rem !important;
+          }
+          .mr-lg-5,
+          .mx-lg-5 {
+            margin-right: 3rem !important;
+          }
+          .mb-lg-5,
+          .my-lg-5 {
+            margin-bottom: 3rem !important;
+          }
+          .ml-lg-5,
+          .mx-lg-5 {
+            margin-left: 3rem !important;
+          }
+          .p-lg-0 {
+            padding: 0 !important;
+          }
+          .pt-lg-0,
+          .py-lg-0 {
+            padding-top: 0 !important;
+          }
+          .pr-lg-0,
+          .px-lg-0 {
+            padding-right: 0 !important;
+          }
+          .pb-lg-0,
+          .py-lg-0 {
+            padding-bottom: 0 !important;
+          }
+          .pl-lg-0,
+          .px-lg-0 {
+            padding-left: 0 !important;
+          }
+          .p-lg-1 {
+            padding: 0.25rem !important;
+          }
+          .pt-lg-1,
+          .py-lg-1 {
+            padding-top: 0.25rem !important;
+          }
+          .pr-lg-1,
+          .px-lg-1 {
+            padding-right: 0.25rem !important;
+          }
+          .pb-lg-1,
+          .py-lg-1 {
+            padding-bottom: 0.25rem !important;
+          }
+          .pl-lg-1,
+          .px-lg-1 {
+            padding-left: 0.25rem !important;
+          }
+          .p-lg-2 {
+            padding: 0.5rem !important;
+          }
+          .pt-lg-2,
+          .py-lg-2 {
+            padding-top: 0.5rem !important;
+          }
+          .pr-lg-2,
+          .px-lg-2 {
+            padding-right: 0.5rem !important;
+          }
+          .pb-lg-2,
+          .py-lg-2 {
+            padding-bottom: 0.5rem !important;
+          }
+          .pl-lg-2,
+          .px-lg-2 {
+            padding-left: 0.5rem !important;
+          }
+          .p-lg-3 {
+            padding: 1rem !important;
+          }
+          .pt-lg-3,
+          .py-lg-3 {
+            padding-top: 1rem !important;
+          }
+          .pr-lg-3,
+          .px-lg-3 {
+            padding-right: 1rem !important;
+          }
+          .pb-lg-3,
+          .py-lg-3 {
+            padding-bottom: 1rem !important;
+          }
+          .pl-lg-3,
+          .px-lg-3 {
+            padding-left: 1rem !important;
+          }
+          .p-lg-4 {
+            padding: 1.5rem !important;
+          }
+          .pt-lg-4,
+          .py-lg-4 {
+            padding-top: 1.5rem !important;
+          }
+          .pr-lg-4,
+          .px-lg-4 {
+            padding-right: 1.5rem !important;
+          }
+          .pb-lg-4,
+          .py-lg-4 {
+            padding-bottom: 1.5rem !important;
+          }
+          .pl-lg-4,
+          .px-lg-4 {
+            padding-left: 1.5rem !important;
+          }
+          .p-lg-5 {
+            padding: 3rem !important;
+          }
+          .pt-lg-5,
+          .py-lg-5 {
+            padding-top: 3rem !important;
+          }
+          .pr-lg-5,
+          .px-lg-5 {
+            padding-right: 3rem !important;
+          }
+          .pb-lg-5,
+          .py-lg-5 {
+            padding-bottom: 3rem !important;
+          }
+          .pl-lg-5,
+          .px-lg-5 {
+            padding-left: 3rem !important;
+          }
+          .m-lg-n1 {
+            margin: -0.25rem !important;
+          }
+          .mt-lg-n1,
+          .my-lg-n1 {
+            margin-top: -0.25rem !important;
+          }
+          .mr-lg-n1,
+          .mx-lg-n1 {
+            margin-right: -0.25rem !important;
+          }
+          .mb-lg-n1,
+          .my-lg-n1 {
+            margin-bottom: -0.25rem !important;
+          }
+          .ml-lg-n1,
+          .mx-lg-n1 {
+            margin-left: -0.25rem !important;
+          }
+          .m-lg-n2 {
+            margin: -0.5rem !important;
+          }
+          .mt-lg-n2,
+          .my-lg-n2 {
+            margin-top: -0.5rem !important;
+          }
+          .mr-lg-n2,
+          .mx-lg-n2 {
+            margin-right: -0.5rem !important;
+          }
+          .mb-lg-n2,
+          .my-lg-n2 {
+            margin-bottom: -0.5rem !important;
+          }
+          .ml-lg-n2,
+          .mx-lg-n2 {
+            margin-left: -0.5rem !important;
+          }
+          .m-lg-n3 {
+            margin: -1rem !important;
+          }
+          .mt-lg-n3,
+          .my-lg-n3 {
+            margin-top: -1rem !important;
+          }
+          .mr-lg-n3,
+          .mx-lg-n3 {
+            margin-right: -1rem !important;
+          }
+          .mb-lg-n3,
+          .my-lg-n3 {
+            margin-bottom: -1rem !important;
+          }
+          .ml-lg-n3,
+          .mx-lg-n3 {
+            margin-left: -1rem !important;
+          }
+          .m-lg-n4 {
+            margin: -1.5rem !important;
+          }
+          .mt-lg-n4,
+          .my-lg-n4 {
+            margin-top: -1.5rem !important;
+          }
+          .mr-lg-n4,
+          .mx-lg-n4 {
+            margin-right: -1.5rem !important;
+          }
+          .mb-lg-n4,
+          .my-lg-n4 {
+            margin-bottom: -1.5rem !important;
+          }
+          .ml-lg-n4,
+          .mx-lg-n4 {
+            margin-left: -1.5rem !important;
+          }
+          .m-lg-n5 {
+            margin: -3rem !important;
+          }
+          .mt-lg-n5,
+          .my-lg-n5 {
+            margin-top: -3rem !important;
+          }
+          .mr-lg-n5,
+          .mx-lg-n5 {
+            margin-right: -3rem !important;
+          }
+          .mb-lg-n5,
+          .my-lg-n5 {
+            margin-bottom: -3rem !important;
+          }
+          .ml-lg-n5,
+          .mx-lg-n5 {
+            margin-left: -3rem !important;
+          }
+          .m-lg-auto {
+            margin: auto !important;
+          }
+          .mt-lg-auto,
+          .my-lg-auto {
+            margin-top: auto !important;
+          }
+          .mr-lg-auto,
+          .mx-lg-auto {
+            margin-right: auto !important;
+          }
+          .mb-lg-auto,
+          .my-lg-auto {
+            margin-bottom: auto !important;
+          }
+          .ml-lg-auto,
+          .mx-lg-auto {
+            margin-left: auto !important;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .m-xl-0 {
+            margin: 0 !important;
+          }
+          .mt-xl-0,
+          .my-xl-0 {
+            margin-top: 0 !important;
+          }
+          .mr-xl-0,
+          .mx-xl-0 {
+            margin-right: 0 !important;
+          }
+          .mb-xl-0,
+          .my-xl-0 {
+            margin-bottom: 0 !important;
+          }
+          .ml-xl-0,
+          .mx-xl-0 {
+            margin-left: 0 !important;
+          }
+          .m-xl-1 {
+            margin: 0.25rem !important;
+          }
+          .mt-xl-1,
+          .my-xl-1 {
+            margin-top: 0.25rem !important;
+          }
+          .mr-xl-1,
+          .mx-xl-1 {
+            margin-right: 0.25rem !important;
+          }
+          .mb-xl-1,
+          .my-xl-1 {
+            margin-bottom: 0.25rem !important;
+          }
+          .ml-xl-1,
+          .mx-xl-1 {
+            margin-left: 0.25rem !important;
+          }
+          .m-xl-2 {
+            margin: 0.5rem !important;
+          }
+          .mt-xl-2,
+          .my-xl-2 {
+            margin-top: 0.5rem !important;
+          }
+          .mr-xl-2,
+          .mx-xl-2 {
+            margin-right: 0.5rem !important;
+          }
+          .mb-xl-2,
+          .my-xl-2 {
+            margin-bottom: 0.5rem !important;
+          }
+          .ml-xl-2,
+          .mx-xl-2 {
+            margin-left: 0.5rem !important;
+          }
+          .m-xl-3 {
+            margin: 1rem !important;
+          }
+          .mt-xl-3,
+          .my-xl-3 {
+            margin-top: 1rem !important;
+          }
+          .mr-xl-3,
+          .mx-xl-3 {
+            margin-right: 1rem !important;
+          }
+          .mb-xl-3,
+          .my-xl-3 {
+            margin-bottom: 1rem !important;
+          }
+          .ml-xl-3,
+          .mx-xl-3 {
+            margin-left: 1rem !important;
+          }
+          .m-xl-4 {
+            margin: 1.5rem !important;
+          }
+          .mt-xl-4,
+          .my-xl-4 {
+            margin-top: 1.5rem !important;
+          }
+          .mr-xl-4,
+          .mx-xl-4 {
+            margin-right: 1.5rem !important;
+          }
+          .mb-xl-4,
+          .my-xl-4 {
+            margin-bottom: 1.5rem !important;
+          }
+          .ml-xl-4,
+          .mx-xl-4 {
+            margin-left: 1.5rem !important;
+          }
+          .m-xl-5 {
+            margin: 3rem !important;
+          }
+          .mt-xl-5,
+          .my-xl-5 {
+            margin-top: 3rem !important;
+          }
+          .mr-xl-5,
+          .mx-xl-5 {
+            margin-right: 3rem !important;
+          }
+          .mb-xl-5,
+          .my-xl-5 {
+            margin-bottom: 3rem !important;
+          }
+          .ml-xl-5,
+          .mx-xl-5 {
+            margin-left: 3rem !important;
+          }
+          .p-xl-0 {
+            padding: 0 !important;
+          }
+          .pt-xl-0,
+          .py-xl-0 {
+            padding-top: 0 !important;
+          }
+          .pr-xl-0,
+          .px-xl-0 {
+            padding-right: 0 !important;
+          }
+          .pb-xl-0,
+          .py-xl-0 {
+            padding-bottom: 0 !important;
+          }
+          .pl-xl-0,
+          .px-xl-0 {
+            padding-left: 0 !important;
+          }
+          .p-xl-1 {
+            padding: 0.25rem !important;
+          }
+          .pt-xl-1,
+          .py-xl-1 {
+            padding-top: 0.25rem !important;
+          }
+          .pr-xl-1,
+          .px-xl-1 {
+            padding-right: 0.25rem !important;
+          }
+          .pb-xl-1,
+          .py-xl-1 {
+            padding-bottom: 0.25rem !important;
+          }
+          .pl-xl-1,
+          .px-xl-1 {
+            padding-left: 0.25rem !important;
+          }
+          .p-xl-2 {
+            padding: 0.5rem !important;
+          }
+          .pt-xl-2,
+          .py-xl-2 {
+            padding-top: 0.5rem !important;
+          }
+          .pr-xl-2,
+          .px-xl-2 {
+            padding-right: 0.5rem !important;
+          }
+          .pb-xl-2,
+          .py-xl-2 {
+            padding-bottom: 0.5rem !important;
+          }
+          .pl-xl-2,
+          .px-xl-2 {
+            padding-left: 0.5rem !important;
+          }
+          .p-xl-3 {
+            padding: 1rem !important;
+          }
+          .pt-xl-3,
+          .py-xl-3 {
+            padding-top: 1rem !important;
+          }
+          .pr-xl-3,
+          .px-xl-3 {
+            padding-right: 1rem !important;
+          }
+          .pb-xl-3,
+          .py-xl-3 {
+            padding-bottom: 1rem !important;
+          }
+          .pl-xl-3,
+          .px-xl-3 {
+            padding-left: 1rem !important;
+          }
+          .p-xl-4 {
+            padding: 1.5rem !important;
+          }
+          .pt-xl-4,
+          .py-xl-4 {
+            padding-top: 1.5rem !important;
+          }
+          .pr-xl-4,
+          .px-xl-4 {
+            padding-right: 1.5rem !important;
+          }
+          .pb-xl-4,
+          .py-xl-4 {
+            padding-bottom: 1.5rem !important;
+          }
+          .pl-xl-4,
+          .px-xl-4 {
+            padding-left: 1.5rem !important;
+          }
+          .p-xl-5 {
+            padding: 3rem !important;
+          }
+          .pt-xl-5,
+          .py-xl-5 {
+            padding-top: 3rem !important;
+          }
+          .pr-xl-5,
+          .px-xl-5 {
+            padding-right: 3rem !important;
+          }
+          .pb-xl-5,
+          .py-xl-5 {
+            padding-bottom: 3rem !important;
+          }
+          .pl-xl-5,
+          .px-xl-5 {
+            padding-left: 3rem !important;
+          }
+          .m-xl-n1 {
+            margin: -0.25rem !important;
+          }
+          .mt-xl-n1,
+          .my-xl-n1 {
+            margin-top: -0.25rem !important;
+          }
+          .mr-xl-n1,
+          .mx-xl-n1 {
+            margin-right: -0.25rem !important;
+          }
+          .mb-xl-n1,
+          .my-xl-n1 {
+            margin-bottom: -0.25rem !important;
+          }
+          .ml-xl-n1,
+          .mx-xl-n1 {
+            margin-left: -0.25rem !important;
+          }
+          .m-xl-n2 {
+            margin: -0.5rem !important;
+          }
+          .mt-xl-n2,
+          .my-xl-n2 {
+            margin-top: -0.5rem !important;
+          }
+          .mr-xl-n2,
+          .mx-xl-n2 {
+            margin-right: -0.5rem !important;
+          }
+          .mb-xl-n2,
+          .my-xl-n2 {
+            margin-bottom: -0.5rem !important;
+          }
+          .ml-xl-n2,
+          .mx-xl-n2 {
+            margin-left: -0.5rem !important;
+          }
+          .m-xl-n3 {
+            margin: -1rem !important;
+          }
+          .mt-xl-n3,
+          .my-xl-n3 {
+            margin-top: -1rem !important;
+          }
+          .mr-xl-n3,
+          .mx-xl-n3 {
+            margin-right: -1rem !important;
+          }
+          .mb-xl-n3,
+          .my-xl-n3 {
+            margin-bottom: -1rem !important;
+          }
+          .ml-xl-n3,
+          .mx-xl-n3 {
+            margin-left: -1rem !important;
+          }
+          .m-xl-n4 {
+            margin: -1.5rem !important;
+          }
+          .mt-xl-n4,
+          .my-xl-n4 {
+            margin-top: -1.5rem !important;
+          }
+          .mr-xl-n4,
+          .mx-xl-n4 {
+            margin-right: -1.5rem !important;
+          }
+          .mb-xl-n4,
+          .my-xl-n4 {
+            margin-bottom: -1.5rem !important;
+          }
+          .ml-xl-n4,
+          .mx-xl-n4 {
+            margin-left: -1.5rem !important;
+          }
+          .m-xl-n5 {
+            margin: -3rem !important;
+          }
+          .mt-xl-n5,
+          .my-xl-n5 {
+            margin-top: -3rem !important;
+          }
+          .mr-xl-n5,
+          .mx-xl-n5 {
+            margin-right: -3rem !important;
+          }
+          .mb-xl-n5,
+          .my-xl-n5 {
+            margin-bottom: -3rem !important;
+          }
+          .ml-xl-n5,
+          .mx-xl-n5 {
+            margin-left: -3rem !important;
+          }
+          .m-xl-auto {
+            margin: auto !important;
+          }
+          .mt-xl-auto,
+          .my-xl-auto {
+            margin-top: auto !important;
+          }
+          .mr-xl-auto,
+          .mx-xl-auto {
+            margin-right: auto !important;
+          }
+          .mb-xl-auto,
+          .my-xl-auto {
+            margin-bottom: auto !important;
+          }
+          .ml-xl-auto,
+          .mx-xl-auto {
+            margin-left: auto !important;
+          }
+        }
+
+        .text-monospace {
+          font-family: "IBM Plex Mono";
+        }
+
+        .text-justify {
+          text-align: justify !important;
+        }
+
+        .text-wrap {
+          white-space: normal !important;
+        }
+
+        .text-nowrap {
+          white-space: nowrap !important;
+        }
+
+        .text-truncate {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .text-left {
+          text-align: left !important;
+        }
+
+        .text-right {
+          text-align: right !important;
+        }
+
+        .text-center {
+          text-align: center !important;
+        }
+
+        @media (min-width: 576px) {
+          .text-sm-left {
+            text-align: left !important;
+          }
+          .text-sm-right {
+            text-align: right !important;
+          }
+          .text-sm-center {
+            text-align: center !important;
+          }
+        }
+
+        @media (min-width: 768px) {
+          .text-md-left {
+            text-align: left !important;
+          }
+          .text-md-right {
+            text-align: right !important;
+          }
+          .text-md-center {
+            text-align: center !important;
+          }
+        }
+
+        @media (min-width: 992px) {
+          .text-lg-left {
+            text-align: left !important;
+          }
+          .text-lg-right {
+            text-align: right !important;
+          }
+          .text-lg-center {
+            text-align: center !important;
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .text-xl-left {
+            text-align: left !important;
+          }
+          .text-xl-right {
+            text-align: right !important;
+          }
+          .text-xl-center {
+            text-align: center !important;
+          }
+        }
+
+        .text-lowercase {
+          text-transform: lowercase !important;
+        }
+
+        .text-uppercase {
+          text-transform: uppercase !important;
+        }
+
+        .text-capitalize {
+          text-transform: capitalize !important;
+        }
+
+        .font-weight-light {
+          font-weight: 300 !important;
+        }
+
+        .font-weight-lighter {
+          font-weight: lighter !important;
+        }
+
+        .font-weight-normal {
+          font-weight: 400 !important;
+        }
+
+        .font-weight-bold {
+          font-weight: 700 !important;
+        }
+
+        .font-weight-bolder {
+          font-weight: bolder !important;
+        }
+
+        .font-italic {
+          font-style: italic !important;
+        }
+
+        .text-white {
+          color: #FFFFFF !important;
+        }
+
+        .text-primary {
+          color: #017FFD !important;
+        }
+
+        a.text-primary:hover,
+        a.text-primary:focus {
+          color: #0159b1 !important;
+        }
+
+        .text-secondary {
+          color: #005EC4 !important;
+        }
+
+        a.text-secondary:hover,
+        a.text-secondary:focus {
+          color: #003978 !important;
+        }
+
+        .text-success {
+          color: #00BD55 !important;
+        }
+
+        a.text-success:hover,
+        a.text-success:focus {
+          color: #007133 !important;
+        }
+
+        .text-info {
+          color: #17a2b8 !important;
+        }
+
+        a.text-info:hover,
+        a.text-info:focus {
+          color: #0f6674 !important;
+        }
+
+        .text-warning {
+          color: #ffc107 !important;
+        }
+
+        a.text-warning:hover,
+        a.text-warning:focus {
+          color: #ba8b00 !important;
+        }
+
+        .text-danger {
+          color: #F36969 !important;
+        }
+
+        a.text-danger:hover,
+        a.text-danger:focus {
+          color: #ed2222 !important;
+        }
+
+        .text-light {
+          color: #FFFFFF !important;
+        }
+
+        a.text-light:hover,
+        a.text-light:focus {
+          color: #d9d9d9 !important;
+        }
+
+        .text-dark {
+          color: #353535 !important;
+        }
+
+        a.text-dark:hover,
+        a.text-dark:focus {
+          color: #0f0f0f !important;
+        }
+
+        .text-body {
+          color: #212529 !important;
+        }
+
+        .text-muted {
+          color: #6c757d !important;
+        }
+
+        .text-black-50 {
+          color: rgba(0, 0, 0, 0.5) !important;
+        }
+
+        .text-white-50 {
+          color: rgba(255, 255, 255, 0.5) !important;
+        }
+
+        .text-hide {
+          font: 0/0 a;
+          color: transparent;
+          text-shadow: none;
+          background-color: transparent;
+          border: 0;
+        }
+
+        .text-decoration-none {
+          text-decoration: none !important;
+        }
+
+        .text-reset {
+          color: inherit !important;
+        }
+
+        .visible {
+          visibility: visible !important;
+        }
+
+        .invisible {
+          visibility: hidden !important;
+        }
+
+        @media print {
+          *,
+          *::before,
+          *::after {
+            text-shadow: none !important;
+            box-shadow: none !important;
+          }
+          a:not(.btn) {
+            text-decoration: underline;
+          }
+          abbr[title]::after {
+            content: " (" attr(title) ")";
+          }
+          pre {
+            white-space: pre-wrap !important;
+          }
+          pre,
+          blockquote {
+            border: 1px solid #adb5bd;
+            page-break-inside: avoid;
+          }
+          thead {
+            display: table-header-group;
+          }
+          tr,
+          img {
+            page-break-inside: avoid;
+          }
+          p,
+          h2,
+          h3 {
+            orphans: 3;
+            widows: 3;
+          }
+          h2,
+          h3 {
+            page-break-after: avoid;
+          }
+          @page {
+            size: a3;
+          }
+          body {
+            min-width: 992px !important;
+          }
+          .container {
+            min-width: 992px !important;
+          }
+          .navbar {
+            display: none;
+          }
+          .badge {
+            border: 1px solid #000;
+          }
+          .table {
+            border-collapse: collapse !important;
+          }
+          .table td,
+          .table th {
+            background-color: #FFFFFF !important;
+          }
+          .table-bordered th,
+          .table-bordered td {
+            border: 1px solid #dee2e6 !important;
+          }
+          .table-dark {
+            color: inherit;
+          }
+          .table-dark th,
+          .table-dark td,
+          .table-dark thead th,
+          .table-dark tbody+tbody {
+            border-color: #dee2e6;
+          }
+          .table .thead-dark th {
+            color: inherit;
+            border-color: #dee2e6;
+          }
+        }
+      helpers.ftl: |-
+        [#ftl/]
+        [#setting url_escaping_charset="UTF-8"]
+        [#-- Below are the main blocks for all of the themeable pages --]
+        [#-- @ftlvariable name="application" type="io.fusionauth.domain.Application" --]
+        [#-- @ftlvariable name="bypassTheme" type="boolean" --]
+        [#-- @ftlvariable name="client_id" type="java.lang.String" --]
+        [#-- @ftlvariable name="code_challenge" type="java.lang.String" --]
+        [#-- @ftlvariable name="code_challenge_method" type="java.lang.String" --]
+        [#-- @ftlvariable name="locale" type="java.util.Locale" --]
+        [#-- @ftlvariable name="loginTheme" type="io.fusionauth.domain.Theme.Templates" --]
+        [#-- @ftlvariable name="metaData" type="io.fusionauth.domain.jwt.RefreshToken.MetaData" --]
+        [#-- @ftlvariable name="nonce" type="java.lang.String" --]
+        [#-- @ftlvariable name="redirect_uri" type="java.lang.String" --]
+        [#-- @ftlvariable name="response_mode" type="java.lang.String" --]
+        [#-- @ftlvariable name="response_type" type="java.lang.String" --]
+        [#-- @ftlvariable name="scope" type="java.lang.String" --]
+        [#-- @ftlvariable name="state" type="java.lang.String" --]
+        [#-- @ftlvariable name="theme" type="io.fusionauth.domain.Theme" --]
+        [#-- @ftlvariable name="timezone" type="java.lang.String" --]
+        [#-- @ftlvariable name="user_code" type="java.lang.String" --]
+        [#-- @ftlvariable name="version" type="java.lang.String" --]
+
+        [#macro html]
+        <!DOCTYPE html>
+        <html lang="en">
+          [#nested/]
+        </html>
+        [/#macro]
+
+        [#macro head title="Login | MOLGENIS" author="MOLGENIS" description="User Management Redefined. A Single Sign-On solution for your entire enterprise."]
+        <head>
+          <title>${title}</title>
+          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+          <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+          <meta name="application-name" content="FusionAuth">
+          <meta name="author" content="FusionAuth">
+          <meta name="description" content="${description}">
+          <meta name="robots" content="index, follow">
+
+          [#-- Favicon Madness --]
+          <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/images/apple-touch-icon-57x57.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/images/apple-touch-icon-114x114.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/images/apple-touch-icon-72x72.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/images/apple-touch-icon-144x144.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/images/apple-touch-icon-60x60.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/images/apple-touch-icon-120x120.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="128x128" href="/images/apple-touch-icon-120x120.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/images/apple-touch-icon-76x76.png" />
+          <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/images/apple-touch-icon-152x152.png" />
+
+          <link rel="icon" type="image/png" href="/images/favicon-196x196.png" sizes="196x196" />
+          <link rel="icon" type="image/png" href="/images/favicon-128.png" sizes="128x128" />
+          <link rel="icon" type="image/png" href="/images/favicon-96x96.png" sizes="96x96" />
+          <link rel="icon" type="image/png" href="/images/favicon-32x32.png" sizes="32x32" />
+          <link rel="icon" type="image/png" href="/images/favicon-16x16.png" sizes="16x16" />
+
+          <meta name="msapplication-TileColor" content="#FFFFFF" />
+          <meta name="msapplication-TileImage" content="/images/mstile-144x144.png" />
+          <meta name="msapplication-square70x70logo" content="/images/mstile-70x70.png" />
+          <meta name="msapplication-square150x150logo" content="/images/mstile-150x150.png" />
+          <meta name="msapplication-wide310x150logo" content="/images/mstile-310x150.png" />
+          <meta name="msapplication-square310x310logo" content="/images/mstile-310x310.png" />
+
+          <!-- Google fonts -->
+          <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=IBM+Plex+Mono&family=IBM+Plex+Sans&display=swap" rel="stylesheet">
+          <link rel="stylesheet" href="/css/font-awesome-4.7.0.min.css"/>
+          <!--<link rel="stylesheet" href="/css/fusionauth-style.css?version=${version}"/>-->
+
+          [#-- Theme Stylesheet, only Authorize defines this boolean.
+              Using the ?no_esc on the stylesheet to allow selectors that contain a > symbols.
+              Once insde of a style tag we are safe and the stylesheet is validated not to contain an end style tag --]
+          [#if !(bypassTheme!false)]
+            <style>
+            ${theme.stylesheet()?no_esc}
+            </style>
+          [/#if]
+
+          <script src="/js/prime-min-1.4.1.js?version=${version}"></script>
+          <script src="/js/oauth2/LocaleSelect.js?version=${version}"></script>
+          <script>
+            "use strict";
+            Prime.Document.onReady(function() {
+              Prime.Document.query('.alert').each(function(e) {
+                var dismissButton = e.queryFirst('.dismiss-button');
+                if (dismissButton !== null) {
+                  new Prime.Widgets.Dismissable(e, dismissButton).initialize();
+                }
+              });
+              Prime.Document.query('[data-tooltip]').each(function(e) {
+                new Prime.Widgets.Tooltip(e).withClassName('tooltip').initialize();
+              });
+              Prime.Document.query('.date-picker').each(function(e) {
+                new Prime.Widgets.DateTimePicker(e).withDateOnly().initialize();
+              });
+              new FusionAuth.OAuth2.LocaleSelect(new Prime.Document.queryById('locale-select'));
+            });
+            FusionAuth.Version = "${version}";
+          </script>
+
+          [#-- The nested, page-specific head HTML goes here --]
+          [#nested/]
+
+        </head>
+        [/#macro]
+
+        [#macro body]
+        <body class="app-sidebar-closed">
+        <main>
+          [#nested/]
+        </main>
+        </body>
+        [/#macro]
+
+        [#macro header]
+          <header class="app-header">
+            <nav class="navbar navbar-light bg-light">
+              <span class="navbar-brand mb-0 h1">MOLGENIS</span>
+              <ul class="navbar-nav">
+                <li class="help nav-item"><a class="nav-link" target="_blank" href="https://fusionauth.io/docs"><i class="fa fa-question-circle-o"></i> ${theme.message('help')}</a></li>
+              </ul>
+            </nav>
+          </header>
+
+          [#nested/]
+        [/#macro]
+
+        [#macro alternativeLoginsScript clientId identityProviders]
+          [#if identityProviders["Facebook"]?has_content]
+            <script src="https://connect.facebook.net/en_US/sdk.js"></script>
+            <script src="/js/identityProvider/Facebook.js?version=${version}" data-app-id="${identityProviders["Facebook"][0].lookupAppId(clientId)}"></script>
+          [/#if]
+          [#if identityProviders["Google"]?has_content]
+            <script src="https://apis.google.com/js/api:client.js"></script>
+            <script src="/js/identityProvider/Google.js?version=${version}" data-client-id="${identityProviders["Google"][0].lookupClientId(clientId)}"></script>
+          [/#if]
+          [#if identityProviders["Twitter"]?has_content]
+            [#-- This is the FusionAuth clientId --]
+            <script src="/js/identityProvider/Twitter.js?version=${version}" data-client-id="${clientId}"></script>
+          [/#if]
+          [#if identityProviders["OpenIDConnect"]?has_content || identityProviders["SAMLv2"]?has_content]
+            <script src="/js/identityProvider/Redirect.js?version=${version}"></script>
+          [/#if]
+        [/#macro]
+
+        [#macro main title="Login"]
+        <main class="container pt-3">
+          [@printErrorAlerts/]
+          [@printInfoAlerts/]
+          <div class="row justify-content-center">
+            <div class="col-xs col-sm-8 col-md-6 col-lg-5 col-xl-4">
+              <div class="card">
+                <img src="https://naughty-keller-161373.netlify.app/blueblue.png" class="card-img-top logo-top"/>
+                <div class="card-body">
+                [#if title?has_content]
+                  <h2 class="card-title">${title}</h2>
+                [/#if]
+                  <main>
+                    <div class="card-text">
+                  [#nested/]
+                    </div>
+                  </main>
+                </div>
+              </div>
+            </div>
+          </div>
+          [#-- don't think we need the locale select
+          <div class="row justify-content-center">
+            <div class="col-xs col-sm-8 col-md-6 col-lg-5 col-xl-4">
+              <label class="select">
+                <select id="locale-select" name="locale" class="form-control custom-select">
+                  <option value="en" [#if locale == 'en']selected[/#if]>English</option>
+                    [#list theme.additionalLocales() as l]
+                      <option value="${l}" [#if locale == l]selected[/#if]>${l.getDisplayLanguage(locale)}</option>
+                    [/#list]
+                </select>
+              </label>
+            </div>
+          </div>--]
+        </main>
+        [/#macro]
+
+        [#macro footer]
+          [#nested/]
+
+          [#-- Powered by FusionAuth branding, remove if you like. --]
+          <div style="position: fixed; bottom: 5px; right: 0; padding-bottom: 5px; padding-right: 10px;">
+            <small class="text-muted" style="padding-right: 2px;">Powered by FusionAuth</small>
+            <img src="/images/favicon-128.png" alt="FusionAuth" width="24" height="24">
+          </div>
+        [/#macro]
+
+        [#-- Below are the social login buttons and helpers --]
+        [#macro facebookButton identityProvider clientId]
+        <button id="facebook-login-button" class="facebook login-button" data-permissions="${identityProvider.lookupPermissions(clientId)!''}">
+          <div>
+            <div class="icon">
+              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 216 216">
+                <path class="cls-1" d="M204.1 0H11.9C5.3 0 0 5.3 0 11.9v192.2c0 6.6 5.3 11.9 11.9 11.9h103.5v-83.6H87.2V99.8h28.1v-24c0-27.9 17-43.1 41.9-43.1 11.9 0 22.2.9 25.2 1.3v29.2h-17.3c-13.5 0-16.2 6.4-16.2 15.9v20.8h32.3l-4.2 32.6h-28V216h55c6.6 0 11.9-5.3 11.9-11.9V11.9C216 5.3 210.7 0 204.1 0z"></path>
+              </svg>
+            </div>
+            <div class="text">${identityProvider.lookupButtonText(clientId)?trim}</div>
+          </div>
+        </button>
+        [/#macro]
+
+        [#macro googleButton identityProvider clientId]
+        <button id="google-login-button" class="google login-button" data-scope="${identityProvider.lookupScope(clientId)!''}">
+          <div>
+            <div class="icon">
+              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+                <g>
+                  <path class="cls-1" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+                  <path class="cls-2" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+                  <path class="cls-3" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+                  <path class="cls-4" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+                  <path class="cls-5" d="M0 0h48v48H0z"></path>
+                </g>
+              </svg>
+            </div>
+            <div class="text">${identityProvider.lookupButtonText(clientId)?trim}</div>
+          </div>
+        </button>
+        [/#macro]
+
+        [#macro twitterButton identityProvider clientId]
+        <button id="twitter-login-button" class="twitter login-button">
+          <div>
+            <div class="icon">
+              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+                <g>
+                  <rect class="cls-1" width="400" height="400"></rect>
+                </g>
+                <g>
+                  <path class="cls-2" d="M153.62,301.59c94.34,0,145.94-78.16,145.94-145.94,0-2.22,0-4.43-.15-6.63A104.36,104.36,0,0,0,325,122.47a102.38,102.38,0,0,1-29.46,8.07,51.47,51.47,0,0,0,22.55-28.37,102.79,102.79,0,0,1-32.57,12.45,51.34,51.34,0,0,0-87.41,46.78A145.62,145.62,0,0,1,92.4,107.81a51.33,51.33,0,0,0,15.88,68.47A50.91,50.91,0,0,1,85,169.86c0,.21,0,.43,0,.65a51.31,51.31,0,0,0,41.15,50.28,51.21,51.21,0,0,1-23.16.88,51.35,51.35,0,0,0,47.92,35.62,102.92,102.92,0,0,1-63.7,22A104.41,104.41,0,0,1,75,278.55a145.21,145.21,0,0,0,78.62,23"></path>
+                  <rect class="cls-3" width="400" height="400"></rect>
+                </g>
+              </svg>
+            </div>
+            <div class="text">${identityProvider.lookupButtonText(clientId)?trim}</div>
+          </div>
+        </button>
+        [/#macro]
+
+        [#macro openIDConnectButton identityProvider clientId]
+        <button class="openid login-button" data-identity-provider-id="${identityProvider.id}">
+          <div>
+            <div class="icon">
+              [#if identityProvider.lookupButtonImageURL(clientId)?has_content]
+                <img src="${identityProvider.lookupButtonImageURL(clientId)}" title="OpenID Connect Logo" alt="OpenID Connect Logo"/>
+              [#else]
+                <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <g id="g2189">
+                    <g id="g2202">
+                      <path class="cls-1" d="M87.57,39.57c-8.9-5.55-21.38-9-34.95-9C25.18,30.59,3,44.31,3,61.17,3,76.64,21.46,89.34,45.46,91.52v-8.9c-16.12-2-28.24-10.87-28.24-21.45,0-12,15.84-21.9,35.4-21.9,9.78,0,18.6,2.41,24.95,6.43l-9,5.62H96.84V33.8Z"></path>
+                      <path class="cls-2" d="M45.46,15.41v76l14.23-8.9V6.22Z"></path>
+                    </g>
+                  </g>
+                </svg>
+              [/#if]
+            </div>
+            <div class="text">${identityProvider.lookupButtonText(clientId)?trim}</div>
+          </div>
+        </button>
+        [/#macro]
+
+        [#macro samlv2Button identityProvider clientId]
+        <button class="samlv2 login-button" data-identity-provider-id="${identityProvider.id}">
+          <div>
+            <div class="icon">
+              [#if identityProvider.lookupButtonImageURL(clientId)?has_content]
+                <img src="${identityProvider.lookupButtonImageURL(clientId)}" title="SAML Login" alt="SAML Login"/>
+              [#else]
+                <img src="${request.contextPath}/images/identityProviders/samlv2.svg" title="SAML 2 Logo" alt="SAML 2 Logo"/>
+              [/#if]
+            </div>
+            <div class="text">${identityProvider.lookupButtonText(clientId)?trim}</div>
+          </div>
+        </button>
+        [/#macro]
+
+        [#macro alternativeLogins clientId identityProviders passwordlessEnabled]
+          [#if identityProviders?has_content || passwordlessEnabled]
+            <div class="login-button-container">
+              <div class="hr-container">
+                <hr>
+                <div class="text-center text-uppercase">${theme.message('or')}</div>
+              </div>
+
+              [#if passwordlessEnabled]
+              <div class="row col pt-1">
+                [@link url = "/oauth2/passwordless"]
+                <i class="fa fa-link"></i>
+                <span>${theme.message('passwordless-button-text')}</span>
+                [/@link]
+              </div>
+              [/#if]
+
+              [#if identityProviders["Facebook"]?has_content]
+              <div class="row col">
+                [@facebookButton identityProvider=identityProviders["Facebook"][0] clientId=clientId /]
+              </div>
+              [/#if]
+
+              [#if identityProviders["Google"]?has_content]
+              <div class="row col">
+                [@googleButton identityProvider=identityProviders["Google"][0] clientId=clientId/]
+              </div>
+              [/#if]
+
+              [#if identityProviders["Twitter"]?has_content]
+              <div class="row col">
+                [@twitterButton identityProvider=identityProviders["Twitter"][0] clientId=clientId/]
+              </div>
+              [/#if]
+
+              [#if identityProviders["OpenIDConnect"]?has_content]
+                [#list identityProviders["OpenIDConnect"] as identityProvider]
+                  <div class="row col">
+                    [@openIDConnectButton identityProvider=identityProvider clientId=clientId/]
+                  </div>
+                [/#list]
+              [/#if]
+
+              [#if identityProviders["SAMLv2"]?has_content]
+                [#list identityProviders["SAMLv2"] as identityProvider]
+                  <div class="row col">
+                    [@samlv2Button identityProvider=identityProvider clientId=clientId/]
+                  </div>
+                [/#list]
+              [/#if]
+            </div>
+          [/#if]
+        [/#macro]
+
+        [#-- Below are the helpers for errors and alerts --]
+
+        [#macro printErrorAlerts]
+          [#if errorMessages?size > 0]
+            [#list errorMessages as m]
+              [@alert message=m type="danger" icon="exclamation-circle"/]
+            [/#list]
+          [/#if]
+        [/#macro]
+
+        [#macro printInfoAlerts]
+          [#if infoMessages?size > 0]
+            [#list infoMessages as m]
+              [@alert message=m type="info" icon="info-circle"/]
+            [/#list]
+          [/#if]
+        [/#macro]
+
+        [#macro alert message type icon includeDismissButton=true]
+        <div class="row">
+          <div class="col">
+            <div class="alert alert-${type}">
+              <i class="fa fa-${icon}"></i>
+                ${message}
+              [#if includeDismissButton]
+                <button type="button" class="close dismiss-button" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+              [/#if]
+            </div>
+          </div>
+        </div>
+        [/#macro]
+
+        [#-- Below are the input helpers for hidden, text, buttons, labels and form errors --]
+
+        [#macro hidden name value="" dateTimeFormat=""]
+          <input type="hidden" name="${name}" [#if value == ""]value="${(name?eval?string)!''}" [#else]value="${value?string}"[/#if]/>
+          [#if dateTimeFormat != ""]
+            <input type="hidden" name="${name}@dateTimeFormat" value="${dateTimeFormat}"/>
+          [/#if]
+        [/#macro]
+
+        [#macro input type name id autocapitalize="none" autocomplete="on" autocorrect="off" autofocus=false spellcheck="false" label="" placeholder="" leftAddon="" required=false tooltip="" disabled=false class="" dateTimeFormat=""]
+        <div class="form-group">
+          [#if label?has_content][#t/]
+            <label for="${id}"[#if (fieldMessages[name]![])?size > 0] class="error"[/#if]>${label}[#if required] <span class="required">*</span>[/#if][#t/]
+            [#if tooltip?has_content][#t/]
+              <i class="fa fa-info-circle" data-tooltip="${tooltip}"></i>[#t/]
+            [/#if][#t/]
+            </label>[#t/]
+          [/#if]
+          [#if leftAddon?has_content]
+          <div class="input-group mb-3">
+          <div class="input-group-prepend">
+            <span class="input-group-text"><i class="fa fa-${leftAddon}"></i></span>
+          </div>
+          [/#if]
+          <input type="${type}" name="${name}" [#if type != "password"]value="${(name?eval!'')}"[/#if] class="${class} form-control" autocapitalize="${autocapitalize}" autocomplete="${autocomplete}" autocorrect="${autocorrect}" spellcheck="${spellcheck}" [#if autofocus]autofocus="autofocus"[/#if] placeholder="${placeholder}[#if required] *[/#if]" [#if disabled]disabled="disabled"[/#if]/>
+          [#if dateTimeFormat != ""]
+            <input type="hidden" name="${name}@dateTimeFormat" value="${dateTimeFormat}"/>
+          [/#if]
+          [#if leftAddon?has_content]
+            </div>
+          [/#if]
+          [@errors field=name/]
+        </div>
+        [/#macro]
+
+        [#macro oauthHiddenFields]
+          [@hidden name="client_id"/]
+          [@hidden name="code_challenge"/]
+          [@hidden name="code_challenge_method"/]
+          [@hidden name="metaData.device.name"/]
+          [@hidden name="metaData.device.type"/]
+          [@hidden name="nonce"/]
+          [@hidden name="redirect_uri"/]
+          [@hidden name="response_mode"/]
+          [@hidden name="response_type"/]
+          [@hidden name="scope"/]
+          [@hidden name="state"/]
+          [@hidden name="tenantId"/]
+          [@hidden name="timezone"/]
+          [@hidden name="user_code"/]
+        [/#macro]
+
+        [#macro errors field]
+        [#if fieldMessages[field]?has_content]
+        <span class="form-text text-danger">[#list fieldMessages[field] as message]${message?no_esc}[#if message_has_next], [/#if][/#list]</span>
+        [/#if]
+        [/#macro]
+
+        [#macro button text icon="arrow-right" color="primary" disabled=false]
+        <button class="btn btn-block mb-3 btn-${color}"[#if disabled] disabled="disabled"[/#if]><i class="fa fa-${icon}"></i> ${text}</button>
+        [/#macro]
+
+        [#macro link url extraParameters=""]
+        <a class="card-link" href="${url}?tenantId=${(tenantId)!''}&client_id=${(client_id?url)!''}&nonce=${(nonce?url)!''}&redirect_uri=${(redirect_uri?url)!''}&response_mode=${(response_mode?url)!''}&response_type=${(response_type?url)!''}&scope=${(scope?url)!''}&state=${(state?url)!''}&timezone=${(timezone?url)!''}&metaData.device.name=${(metaData.device.name?url)!''}&metaData.device.type=${(metaData.device.type?url)!''}${extraParameters!''}&code_challenge=${(code_challenge?url)!''}&code_challenge_method=${(code_challenge_method?url)!''}&user_code=${(user_code?url)!''}">
+        [#nested/]
+        </a>
+        [/#macro]
+
+        [#macro passwordRules passwordValidationRules]
+        <div class="font-italic">
+          <span>
+            ${theme.message('password-constraints-intro')}
+          </span>
+          <ul>
+            <li>${theme.message('password-length-constraint', passwordValidationRules.minLength, passwordValidationRules.maxLength)}</li>
+            [#if passwordValidationRules.requireMixedCase]
+              <li>${theme.message('password-case-constraint')}</li>
+            [/#if]
+            [#if passwordValidationRules.requireNonAlpha]
+              <li>${theme.message('password-alpha-constraint')}</li>
+            [/#if]
+            [#if passwordValidationRules.requireNumber]
+              <li>${theme.message('password-number-constraint')}</li>
+            [/#if]
+            [#if passwordValidationRules.rememberPreviousPasswords.enabled]
+              <li>${theme.message('password-previous-constraint', passwordValidationRules.rememberPreviousPasswords.count)}</li>
+            [/#if]
+          </ul>
+        </div>
+        [/#macro]
+      oauth2Authorize.ftl: |-
+        [#ftl/]
+        [#setting url_escaping_charset="UTF-8"]
+        [#-- @ftlvariable name="client_id" type="java.lang.String" --]
+        [#-- @ftlvariable name="code_challenge" type="java.lang.String" --]
+        [#-- @ftlvariable name="code_challenge_method" type="java.lang.String" --]
+        [#-- @ftlvariable name="hasDomainBasedIdentityProviders" type="boolean" --]
+        [#-- @ftlvariable name="identityProviders" type="java.util.Map<java.lang.String, java.util.List<io.fusionauth.domain.provider.BaseIdentityProvider<?>>>" --]
+        [#-- @ftlvariable name="loginId" type="java.lang.String" --]
+        [#-- @ftlvariable name="metaData" type="io.fusionauth.domain.jwt.RefreshToken.MetaData" --]
+        [#-- @ftlvariable name="nonce" type="java.lang.String" --]
+        [#-- @ftlvariable name="passwordlessEnabled" type="boolean" --]
+        [#-- @ftlvariable name="redirect_uri" type="java.lang.String" --]
+        [#-- @ftlvariable name="response_type" type="java.lang.String" --]
+        [#-- @ftlvariable name="scope" type="java.lang.String" --]
+        [#-- @ftlvariable name="showPasswordField" type="boolean" --]
+        [#-- @ftlvariable name="state" type="java.lang.String" --]
+        [#-- @ftlvariable name="timezone" type="java.lang.String" --]
+        [#-- @ftlvariable name="user_code" type="java.lang.String" --]
+        [#-- @ftlvariable name="version" type="java.lang.String" --]
+
+        [#import "../_helpers.ftl" as helpers/]
+
+        [@helpers.html]
+          [@helpers.head]
+            <script src="/js/jstz-min-1.0.6.js"></script>
+            <script src="/js/oauth2/Authorize.js?version=${version}"></script>
+            [@helpers.alternativeLoginsScript clientId=client_id identityProviders=identityProviders/]
+            <script>
+              Prime.Document.onReady(function() {
+                [#-- This object handles guessing the timezone and filling in the device id of the user --]
+                new FusionAuth.OAuth2.Authorize();
+                [#--
+                To use an in-progress indicator when waiting for an external identity provider such as Google.
+                  - The panel class will make the default FusionAuth login panel show "in progress". Modify
+                    this selector if your HTML has been modified, or use your own in progress indicator.
+                --]
+                var panel = Prime.Document.queryFirst('.panel');
+                if (panel !== null) {
+                  FusionAuth = FusionAuth || {};
+                  FusionAuth.IdentityProvider = FusionAuth.IdentityProvider || {};
+                  FusionAuth.IdentityProvider.InProgress = new Prime.Widgets.InProgress(panel);
+                }
+              });
+            </script>
+          [/@helpers.head]
+          [@helpers.body]
+
+            [@helpers.header]
+              [#-- Custom header code goes here --]
+            [/@helpers.header]
+
+
+            [@helpers.main title=theme.message('login')]
+              <form action="authorize" method="POST">
+                [@helpers.oauthHiddenFields/]
+                [@helpers.hidden name="showPasswordField"/]
+                [#if showPasswordField && hasDomainBasedIdentityProviders]
+                  [@helpers.hidden name="loginId"/]
+                [/#if]
+
+                <fieldset>
+                  [@helpers.input type="text" name="loginId" id="loginId" autocomplete="username" autocapitalize="none" autocomplete="on" autocorrect="off" spellcheck="false" autofocus=(!loginId?has_content) placeholder=theme.message('loginId') leftAddon="user" disabled=(showPasswordField && hasDomainBasedIdentityProviders)/]
+                  [#if showPasswordField]
+                    [@helpers.input type="password" name="password" id="password" autocomplete="current-password" autofocus=loginId?has_content placeholder=theme.message('password') leftAddon="lock"/]
+                  [/#if]
+                </fieldset>
+
+
+                  [#if showPasswordField]
+                    [@helpers.button icon="key" text=theme.message('submit')/]
+                    [@helpers.link url="/password/forgot"]${theme.message('forgot-your-password')}[/@helpers.link]
+                  [#else]
+                    [@helpers.button icon="arrow-right" text=theme.message('next')/]
+                  [/#if]
+
+              </form>
+              <div>
+                [#if showPasswordField && hasDomainBasedIdentityProviders]
+                  [@helpers.link url="" extraParameters="&showPasswordField=false"]${theme.message('sign-in-as-different-user')}[/@helpers.link]
+                [/#if]
+              </div>
+              [#if application.registrationConfiguration.enabled]
+                <div class="row col pt-1">
+              ${theme.message('dont-have-an-account')}
+            </div>
+            <div class="row col">
+                  [@helpers.link url="register"]${theme.message('create-an-account')}[/@helpers.link]
+                </div>
+              [/#if]
+              [@helpers.alternativeLogins clientId=client_id identityProviders=identityProviders passwordlessEnabled=passwordlessEnabled/]
+            [/@helpers.main]
+
+            [@helpers.footer]
+              [#-- Custom footer code goes here --]
+            [/@helpers.footer]
+
+          [/@helpers.body]
+        [/@helpers.html]
+      oauth2Logout.ftl: |-
+        [#ftl/]
+        [#-- @ftlvariable name="allLogoutURLs" type="java.util.Set<java.lang.String>" --]
+        [#-- @ftlvariable name="registeredLogoutURLs" type="java.util.Set<java.lang.String>" --]
+        [#-- @ftlvariable name="redirectURL" type="java.lang.String" --]
+        [#import "../_helpers.ftl" as helpers/]
+
+        [#-- You may adjust the duration before we redirect the user --]
+        [#assign logoutDurationInSeconds = 2 /]
+
+        [@helpers.html]
+          [@helpers.head title=theme.message('logout-title')]
+          [#if redirectURL?has_content]
+            <meta http-equiv="Refresh" content="${logoutDurationInSeconds}; url=${redirectURL}">
+          [/#if]
+          [/@helpers.head]
+          [@helpers.body]
+            [@helpers.header]
+              [#-- Custom header code goes here --]
+            [/@helpers.header]
+
+            [@helpers.main title=theme.message('logging-out')]
+              <div class="progress">
+              <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
+        </div>
+            [/@helpers.main]
+
+            [#-- use allLogoutURLs to call the logout URL of all applications in the tenant, or use registeredLogoutURLs to log out of just the applications the user is registered for --]
+            [#list allLogoutURLs![] as logoutURL]
+              <iframe src="${logoutURL}" style="width:0; height:0; border:0; border:none;"></iframe>
+            [/#list]
+
+            [@helpers.footer]
+              [#-- Custom footer code goes here --]
+            [/@helpers.footer]
+          [/@helpers.body]
+        [/@helpers.html]
   ingress:
     enabled: "true"
     hosts:


### PR DESCRIPTION
Adds a theme called `MOLGENIS Blue` at boot time using a kickstart script.
First copies the default theme and then overwrites the necessary theme fields.

To see it in action, edit the Default tenant and select the theme.

Helm is a bit clunky, so we have to inline the files into values.yaml, and cannot provide yaml to convert to kickstart.json either. But we can feed the api key to create from questions right into the script through an environment variables.

I noticed that the subchart got upgraded and this one cannot yet handle kubernetes 1.16.
So I had to test on the dev cluster.

When upgrading you also have to start providing your own elasticsearch and postgres so I suggest to do that in a different PR.

#### Checklist
- [x] Functionality works & meets specifications (tested on rancher)
- [x] Templates reviewed
- [x] Added values to questions
- [x] Bumped the chart version
- Updated appVersion (if needed)
