### PR TITLE
fix: Lifelines default app proxy path

### DIFF
--- a/charts/lifelines-webshop/Chart.yaml
+++ b/charts/lifelines-webshop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: lifelines-webshop
 description: A Helm chart for Kubernetes
 type: application
-version: 0.4.9
+version: 0.4.10
 appVersion: 0.32.1
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git

--- a/charts/lifelines-webshop/questions.yaml
+++ b/charts/lifelines-webshop/questions.yaml
@@ -75,7 +75,7 @@ questions:
 
   - variable: "molgenis.molgenis-frontend.proxy.experimental[0].url"
     label: Webshop URL on unpkg.com
-    default: "https://unpkg.com/@molgenis-experimental/molgenis-app-lifelines-webshop"
+    default: "https://unpkg.com/@molgenis-experimental"
     description: "To pin a specific version, include it in the url, e.g. https://unpkg.com/@molgenis-experimental/molgenis-app-lifelines-webshop@0.22.x/"
     type: string
     required: true
@@ -83,7 +83,7 @@ questions:
 
   - variable: "molgenis.molgenis-frontend.proxy.experimental[0].path"
     label: Webapp proxy path
-    default: "@molgenis-experimental/molgenis-app-lifelines-webshop"
+    default: "@molgenis-experimental"
     type: string
     required: true
     hidden: true

--- a/charts/lifelines-webshop/values.yaml
+++ b/charts/lifelines-webshop/values.yaml
@@ -70,8 +70,8 @@ molgenis:
           enabled: false
         url: "http://molgenis:8080"
       experimental:
-        - path: "@molgenis-experimental/molgenis-app-lifelines-webshop"
-          url: https://unpkg.com/@molgenis-experimental/molgenis-app-lifelines-webshop@0.32.1
+        - path: "@molgenis-experimental"
+          url: https://unpkg.com/@molgenis-experimental
           unpkg: true
       custom:
         - path: "edge-server"


### PR DESCRIPTION
Update the default path to sync with the path as expected by the app ans used in PROD and ACC environments

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
