### PR TITLE
fix(jenkins): update plugins

### DIFF
--- a/charts/molgenis-jenkins/Chart.yaml
+++ b/charts/molgenis-jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: molgenis-jenkins
 home: https://jenkins.io/
-version: 1.10.0
+version: 1.9.0
 appVersion: 2.249
 description: Molgenis installation for the jenkins chart.
 sources:

--- a/charts/molgenis-jenkins/Chart.yaml
+++ b/charts/molgenis-jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 name: molgenis-jenkins
 home: https://jenkins.io/
 version: 1.9.0
-appVersion: 2.249
+appVersion: 2.263
 description: Molgenis installation for the jenkins chart.
 sources:
   - https://github.com/molgenis/molgenis-ops-helm.git

--- a/charts/molgenis-jenkins/questions.yml
+++ b/charts/molgenis-jenkins/questions.yml
@@ -4,7 +4,7 @@ categories:
 questions:
 - variable: jenkins.master.tag
   label: Version
-  default: "2.249.2"
+  default: "2.263.3"
   type: string
   required: true
   group: "Provisioning"

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -9,24 +9,24 @@ jenkins:
     jenkinsUrlProtocol: "https"
     serviceType: ClusterIP
     installPlugins:
-      - slack:2.42
-      - kubernetes:1.27.2
+      - slack:2.45
+      - kubernetes:1.27.7
       - workflow-aggregator:2.6
       - workflow-job:2.40
-      - credentials-binding:1.23
+      - credentials-binding:1.24
       - embeddable-build-status:2.0.3
-      - git:4.4.4
-      - github-branch-source:2.9.1
+      - git:4.5.1
+      - github-branch-source:2.9.3
       - basic-branch-build-strategies:1.3.2
       - kubernetes-credentials-provider:0.15
-      - blueocean:1.24.1
+      - blueocean:1.24.3
       - pipeline-github-lib:1.0
       - github-scm-trait-commit-skip:0.4.0
-      - ansible:1.0
-      - prometheus:2.0.7
+      - ansible:1.1
+      - prometheus:2.0.8
       - github-pullrequest:0.2.8
-      - token-macro:2.12
-      - configuration-as-code:1.43
+      - token-macro:2.13
+      - configuration-as-code:1.46
       - job-dsl:1.77
       - block-queued-job:0.2.0
       - build-token-root:1.7

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -10,7 +10,7 @@ jenkins:
     serviceType: ClusterIP
     installPlugins:
       - slack:2.45
-      - kubernetes:1.29
+      - kubernetes:1.27.7
       - workflow-aggregator:2.6
       - workflow-job:2.40
       - credentials-binding:1.24

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -566,10 +566,10 @@ jenkins:
               command: "/bin/bash"
               args: ""
             - name: centos-8
-              image: "centos8.3.2011"
+              image: "centos:centos8.3.2011"
               ttyEnabled: true
               command: "/bin/bash"
-              args: ""
+              args: "--tmpfs /run --tmpfs /tmp -v /sys/fs/cgroup:/sys/fs/cgroup:ro"
       r-3.5.2: |
         - name: r-3.5.2
           label: r-3.5.2

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -2,7 +2,7 @@ jenkins:
   clusterZone: "edgecluster.local"
   master:
     image: "jenkins/jenkins"
-    tag: "2.249.2"
+    tag: "2.263.3"
     ingress:
       enabled: true
       hostName: jenkins.dev.molgenis.org

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -373,6 +373,36 @@ jenkins:
                 - envVar:
                     key: HOME
                     value: /home/jenkins/agent
+      molgenis-jdk13: |
+        - name: molgenis-jdk13
+          label: molgenis-jdk13
+          inheritFrom: shared
+          nodeUsageMode: EXCLUSIVE
+          containers:
+            - name: java
+              image: "openjdk:13-alpine"
+              command: cat
+              args: ""
+              resourceRequestCpu: "1"
+              resourceRequestMemory: "1Gi"
+            - name: postgres
+              image: postgres:13-alpine
+              workingDir: ""
+              command: ""
+              args: "-c shared_buffers=256MB -c max_locks_per_transaction=1024"
+              resourceRequestCpu: "100m"
+              resourceRequestMemory: "1Gi"
+              resourceLimitMemory: "1Gi"
+              envVars:
+                - envVar:
+                    key: POSTGRES_USER
+                    value: molgenis
+                - envVar:
+                    key: POSTGRES_PASSWORD
+                    value: molgenis
+                - envVar:
+                    key: POSTGRES_DB
+                    value: molgenis
       node: |
         - name: node
           label: node-carbon
@@ -532,6 +562,11 @@ jenkins:
           containers:
             - name: centos-6
               image: "centos:6.10"
+              ttyEnabled: true
+              command: "/bin/bash"
+              args: ""
+            - name: centos-8
+              image: "centos8.3.2011"
               ttyEnabled: true
               command: "/bin/bash"
               args: ""

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -10,7 +10,7 @@ jenkins:
     serviceType: ClusterIP
     installPlugins:
       - slack:2.45
-      - kubernetes:1.27.7
+      - kubernetes:1.29
       - workflow-aggregator:2.6
       - workflow-job:2.40
       - credentials-binding:1.24


### PR DESCRIPTION
Done because kubernetes plugin does not respond correctly when there is much load on the cluster.
Kubernetes plugin version 1.27.3 contains concurrency fixes which hopefully help solving the problem.

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
