### PR TITLE
feat(jenkins): upgrade rancher cli in shared build pod to 2.4.10

### DIFF
--- a/charts/molgenis-jenkins/Chart.yaml
+++ b/charts/molgenis-jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: molgenis-jenkins
 home: https://jenkins.io/
-version: 1.11.1
+version: 1.12.0
 appVersion: 2.263
 description: Molgenis installation for the jenkins chart.
 sources:

--- a/charts/molgenis-jenkins/values.yaml
+++ b/charts/molgenis-jenkins/values.yaml
@@ -276,7 +276,7 @@ jenkins:
               args: ""
               ttyEnabled: true
             - name: rancher
-              image: "rancher/cli2:v2.2.0"
+              image: "rancher/cli2:v2.4.10"
               command: cat
               args: ""
               ttyEnabled: true


### PR DESCRIPTION
The armadillo build was broken cause it no longer could deploy the latest version to the dev cluster.
I think we were running into an issue with the rancher cli, cause the same command did work from the command line on my laptop.

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
