### PR TITLE
Make KES key creation easier in Armadillo

### DIFF
--- a/charts/molgenis-armadillo/Chart.yaml
+++ b/charts/molgenis-armadillo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for MOLGENIS Armadillo
 name: molgenis-armadillo
-version: 0.10.0
+version: 0.11.0
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 - https://github.com/molgenis/molgenis-service-armadillo.git

--- a/charts/molgenis-armadillo/README.md
+++ b/charts/molgenis-armadillo/README.md
@@ -4,4 +4,36 @@ This chart deploys a MOLGENIS Armadillo server with an RServe backend and a mini
 
 Data managers can upload data sets into the file store. Researchers can analyze these data sets across multiple instances using DataSHIELD.
 
+## MinIO file encryption
+By default the chart encrypts the files in MinIO using a KES server.
+The MinIO server communicates with the KES server using mutual TLS.
+
+The KES server's public certificate needs to be trusted by MinIO.
+There's a rancher question where you must fill it in.
+You can find it in the kes server's secret.
+
+When deployed, this chart generates a key pair client.key and client.cert to use in communication with the server.
+It also creates two jobs.
+The first job logs the identity of the client certificate.
+Upgrade the KES server, adding a policy that allows the MinIO client key to use a 
+specific KES key. So for example if your deployment is going to use a key named gecko, add this to the KES server's policy:
+```
+gecko:
+  paths:
+    - /v1/key/create/gecko*
+    - /v1/key/generate/gecko*
+    - /v1/key/decrypt/gecko*
+  identities:
+    - <here you fill in the client key identity logged by the job>
+```
+Then restart the kes pods so that they pick up the policy.
+
+The second job tries to create the key on the kes server (MinIO won't do that for you).
+Initially it will fail because the policy forbids key creation.
+It should succeed once the policy is configured and the kes pods have restarted.
+
+After six tries the job gives up. But if you delete the failed job pods it will start trying again.
+If the key has already been created, it will fail but with a message that says so.
+The jobs are only there for your convenience, feel free to delete them once everything is set up correctly.
+
 > We use the Armadillo icon from: [Armadillo vectors by vecteezy](https://www.vecteezy.com/free-vector/armadillo)

--- a/charts/molgenis-armadillo/templates/kes-certificate-identity-job.yaml
+++ b/charts/molgenis-armadillo/templates/kes-certificate-identity-job.yaml
@@ -10,7 +10,8 @@ spec:
     spec:
       containers:
       - name: kes
-        image: minio/kes:latest
+        image: "{{ .Values.kes.image.repository }}:{{ .Values.kes.image.tag }}"
+        imagePullPolicy: {{ .Values.kes.image.pullPolicy }}
         args:
         - tool
         - identity

--- a/charts/molgenis-armadillo/templates/kes-certificate-identity-job.yaml
+++ b/charts/molgenis-armadillo/templates/kes-certificate-identity-job.yaml
@@ -1,0 +1,32 @@
+{{- if eq .Values.minio.environment.MINIO_KMS_AUTO_ENCRYPTION "on" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kes-certificate-identity
+  labels:
+{{ include "molgenis-armadillo.labels" . | indent 4 }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: kes
+        image: minio/kes:latest
+        args:
+        - tool
+        - identity
+        - of
+        - /certs/client.cert
+        env:
+        - name: KES_CLIENT_CERT
+          value: /certs/client.cert
+        volumeMounts:
+        - name: certs
+          mountPath: "/certs"
+          readOnly: true
+      restartPolicy: Never
+      backoffLimit: 1
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ .Values.minio.trustedCertsSecret }}
+{{- end -}}

--- a/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
+++ b/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
@@ -1,0 +1,36 @@
+{{- if eq .Values.minio.environment.MINIO_KMS_AUTO_ENCRYPTION "on" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kes-create-key
+  labels:
+{{ include "molgenis-armadillo.labels" . | indent 4 }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: kes
+        image: minio/kes:latest
+        args:
+        - key
+        - create
+        - -k
+        - {{ .Values.minio.environment.MINIO_KMS_KES_KEY_NAME }}
+        env:
+        - name: KES_CLIENT_KEY
+          value: /certs/client.key
+        - name: KES_CLIENT_CERT
+          value: /certs/client.cert
+        - name: KES_SERVER
+          value: https://kes.kes.svc:7373
+        volumeMounts:
+        - name: certs
+          mountPath: "/certs"
+          readOnly: true
+      restartPolicy: Never
+      backoffLimit: 1
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ .Values.minio.trustedCertsSecret }}
+{{- end -}}

--- a/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
+++ b/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
@@ -10,7 +10,8 @@ spec:
     spec:
       containers:
       - name: kes
-        image: minio/kes:latest
+        image: "{{ .Values.kes.image.repository }}:{{ .Values.kes.image.tag }}"
+        imagePullPolicy: {{ .Values.kes.image.pullPolicy }}
         args:
         - key
         - create

--- a/charts/molgenis-armadillo/values.yaml
+++ b/charts/molgenis-armadillo/values.yaml
@@ -137,6 +137,12 @@ minio:
   nodeSelector:
     deployPod: "true"
 
+kes:
+  image:
+    repository: minio/kes
+    tag: latest
+    pullPolicy: IfNotPresent
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
Creates two jobs.
First job computes the client key identity so you can easily update the kes server's policy.
Second job keeps trying to create the key, once the kes server has been upgraded it will succeed

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
