### PR TITLE
fix(armadillo): restart kes pod on failure

### DIFF
--- a/charts/molgenis-armadillo/Chart.yaml
+++ b/charts/molgenis-armadillo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.0.17"
 description: A Helm chart for MOLGENIS Armadillo
 name: molgenis-armadillo
-version: 0.12.2
+version: 0.12.3
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 - https://github.com/molgenis/molgenis-service-armadillo.git

--- a/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
+++ b/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
@@ -28,7 +28,7 @@ spec:
         - name: certs
           mountPath: "/certs"
           readOnly: true
-      restartPolicy: Never
+      restartPolicy: OnFailure
       backoffLimit: 1
       volumes:
       - name: certs

--- a/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
+++ b/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
@@ -29,7 +29,7 @@ spec:
           mountPath: "/certs"
           readOnly: true
       restartPolicy: OnFailure
-      backoffLimit: 1
+      backoffLimit: 20
       volumes:
       - name: certs
         secret:

--- a/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
+++ b/charts/molgenis-armadillo/templates/kes-key-create-job.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ include "molgenis-armadillo.labels" . | indent 4 }}
 spec:
+  backoffLimit: 20
   template:
     spec:
       containers:
@@ -29,7 +30,6 @@ spec:
           mountPath: "/certs"
           readOnly: true
       restartPolicy: OnFailure
-      backoffLimit: 20
       volumes:
       - name: certs
         secret:


### PR DESCRIPTION
Will now create a single pod that keeps trying to create the key with increasing backoff times.
The times are not configurable in k8s but in practice it keeps increasing until you reach 6 minutes.
The pod keeps retrying twenty times, that should give you plenty time to configure the kes server.

#### Checklist
- [x] Functionality works & meets specifications (tested on rancher)
- [x] Templates reviewed
- Added values to questions
- [x] Bumped the chart version
- Updated appVersion (if needed)
