### PR TITLE
fix(molgenis): update openid basic -> client_secret_basic

### DIFF
--- a/charts/molgenis/Chart.yaml
+++ b/charts/molgenis/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "9.1"
+appVersion: "10"
 description: MOLGENIS - helm stack
 name: molgenis
-version: 1.15.8
+version: 1.15.9
 sources:
 - https://github.com/molgenis/molgenis-ops-helm.git
 icon: https://raw.githubusercontent.com/molgenis/molgenis-ops-helm/master/charts/molgenis/catalogIcon-molgenis.png

--- a/charts/molgenis/templates/oidc-secret.yaml
+++ b/charts/molgenis/templates/oidc-secret.yaml
@@ -12,5 +12,5 @@ type: Opaque
 stringData:
   sys_sec_oidc_OidcClient.csv: |-
     registrationId,clientId,clientSecret,clientName,clientAuthenticationMethod,authorizationGrantType,scopes,claimsRolePath,claimsVoGroupPath,issuerUri
-    {{ .Values.oidc.id }},{{ .Values.oidc.identification.client_id }},{{ .Values.oidc.identification.client_secret }},{{ .Values.oidc.name }},basic,authorization_code,"openid,email,profile",{{ .Values.oidc.claims.roles }},{{ .Values.oidc.claims.vo_group }},{{ .Values.oidc.identification.issuerUri }}
+    {{ .Values.oidc.id }},{{ .Values.oidc.identification.client_id }},{{ .Values.oidc.identification.client_secret }},{{ .Values.oidc.name }},client_secret_basic,authorization_code,"openid,email,profile",{{ .Values.oidc.claims.roles }},{{ .Values.oidc.claims.vo_group }},{{ .Values.oidc.identification.issuerUri }}
 {{ end -}}


### PR DESCRIPTION
In molgenis/molgenis#9320 I updated the enum value from `basic` to `client_secret_basic` because spring security deprecated `basic`, but I forgot all about the job

#### Checklist
- [ ] Functionality works & meets specifications (tested on rancher)
- [ ] Templates reviewed
- [ ] Added values to questions
- [ ] Bumped the chart version
- [ ] Updated appVersion (if needed)
