### PR TITLE
chore: fix nightly build

### DIFF
--- a/charts/molgenis-jenkins/resources/tests/nightly/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/nightly/Jenkinsfile
@@ -1,12 +1,14 @@
 pipeline {
     agent {
         kubernetes {
-            inheritFrom 'molgenis-jdk11'
+            inheritFrom 'shared'
+            // maven jdk17 pod template defined in molgenis/molgenis-jenkins-pipeline library
+            yaml libraryResource("pod-templates/maven-jdk17.yaml")
         }
     }
     environment {
         LOCAL_REPOSITORY = "${LOCAL_REGISTRY}/molgenis/molgenis-app"
-        CHART_VERSION = '1.13.0'
+        CHART_VERSION = '1.15.8'
         BRANCH_NAME = 'master'
         TIMESTAMP = sh(returnStdout: true, script: "date -u +'%F_%H-%M-%S'").trim()
     }


### PR DESCRIPTION
The nightly build has broken since https://jenkins.dev.molgenis.org/job/test-nightly/512/ because spring updated some plugin versions.
Also, since jdk17 it needs to build in jdk17 maven build pod.
This uses the new pod added to the jenkins pipeline library.

#### Checklist
- [x] Functionality works & meets specifications (tested on rancher)
- Templates reviewed
- Added values to questions
- Bumped the chart version
- Updated appVersion (if needed)
