### PR TITLE
fix: commander test namespace

### DIFF
--- a/charts/molgenis-jenkins/resources/tests/e2e-commander/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/tests/e2e-commander/Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
                     sh "rancher apps install " +
                             "p-vx5vf:molgenis-helm3-molgenis " +
                             "${TAG} " +
+                            "-n ${TAG} " +
                             "--no-prompt " +
                             "--set adminPassword=admin " +
                             "--set molgenis-frontend.environment=dev " +


### PR DESCRIPTION
De build faalt nog steeds omdat hij een chart bump wil. Dat hoeft niet omdat dit geen resources zijn die met de chart worden uitgerold. Dit wordt elke nacht opgevraagd door de commander job en is alleen van belang voor de jobconfig.